### PR TITLE
SDCORE-830: traffic-data is set in SmPolicyData from

### DIFF
--- a/service/init.go
+++ b/service/init.go
@@ -558,6 +558,9 @@ func UpdatePcfSubsriberPolicyData(slice *protos.NetworkSlice) {
 					for index, element := range pccPolicy.QosDecs {
 						policyData.PccPolicy[sliceid].QosDecs[index] = element
 					}
+					for index, element := range pccPolicy.TraffContDecs {
+						policyData.PccPolicy[sliceid].TraffContDecs[index] = element
+					}
 				}
 				self.DisplayPcfSubscriberPolicyData(imsi)
 			}


### PR DESCRIPTION
traffic-data in pccRule. Code missed to set tarffic-data
PccRule in case of SliceUpdate.