### PR TITLE
strconv.parseint error fix

### DIFF
--- a/service/init.go
+++ b/service/init.go
@@ -464,14 +464,14 @@ func GetBitRateUnit(val int64) (int64, string) {
 		val = 1
 		return val, unit
 	}
-	if val >= 0xFFFF {
+	if val >= 0x7FFF {
 		val = (val / 1000)
 		unit = " Kbps"
-		if val >= 0xFFFF {
+		if val >= 0x7FFF {
 			val = (val / 1000)
 			unit = " Mbps"
 		}
-		if val >= 0xFFFF {
+		if val >= 0x7FFF {
 			val = (val / 1000)
 			unit = " Gbps"
 		}


### PR DESCRIPTION
40000 is > 0x7FFF hence returns error. Fixed it in PCF to give value
      with in the range 0 to 0x7FFF