### PR TITLE
chore: Adds go setup in CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
       - name: Build
         run: go build
 
@@ -24,6 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
 
       - name: Unit tests
         run: go test ./...


### PR DESCRIPTION
## Description

This PR sets up Go with a specific version (1.21) in the CI. By default right now the Ubuntu version is 1.20. The goal with this PR is to avoid errors where the go version does not match the one we need to build and test the code.
