### PR TITLE
fix: Ignore UDR URI caches

### DIFF
--- a/producer/ampolicy.go
+++ b/producer/ampolicy.go
@@ -417,8 +417,5 @@ func SendAMPolicyTerminationRequestNotification(ue *pcf_context.UeContext,
 
 // returns UDR Uri of Ue, if ue.UdrUri dose not exist, query NRF to get supported Udr Uri
 func getUdrUri(ue *pcf_context.UeContext) string {
-	if ue.UdrUri != "" {
-		return ue.UdrUri
-	}
 	return consumer.SendNFIntancesUDR(pcf_context.PCF_Self().NrfUri, ue.Supi)
 }

--- a/producer/bdtpolicy.go
+++ b/producer/bdtpolicy.go
@@ -182,7 +182,6 @@ func createBDTPolicyContextProcedure(request *models.BdtReqData) (
 		logger.Bdtpolicylog.Warnf(problemDetails.Detail)
 		return nil, nil, problemDetails
 	}
-	pcfSelf.DefaultUdrURI = udrUri
 	pcfSelf.SetDefaultUdrURI(udrUri)
 
 	// Query BDT DATA array from UDR
@@ -274,9 +273,6 @@ func createBDTPolicyContextProcedure(request *models.BdtReqData) (
 func getDefaultUdrUri(context *pcf_context.PCFContext) string {
 	context.DefaultUdrURILock.RLock()
 	defer context.DefaultUdrURILock.RUnlock()
-	if context.DefaultUdrURI != "" {
-		return context.DefaultUdrURI
-	}
 	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
 		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NUDR_DR}),
 	}


### PR DESCRIPTION
Ignore the caches of the UDR URI, as it causes issue when the UDR crashes and changes IP.