### PR TITLE
chore: Uses go version from go.mod

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: 'go.mod'
 
       - name: Build
         run: go build

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: "go.mod"
 
       - name: Build
         run: go build
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: "go.mod"
 
       - name: Unit tests
         run: go test ./...

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: 'go.mod'
 
       - name: Unit tests
         run: go test ./...


### PR DESCRIPTION
# Description

We use the go version from go.mod instead of specifying it in CI. This makes it so that when we will bump the Go version we will have to do it in less places and therefore avoids potential differences between the go version running in CI and the one in go.mod.