### PR TITLE
chore: Adds lint checks to CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,3 +35,18 @@ jobs:
 
       - name: Unit tests
         run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          version: latest
+          args: -v --config ./.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -220,19 +220,16 @@ linters-settings:
 
 linters:
   enable:
-    - gofmt
-    - govet
-    - errcheck
-    - staticcheck
-    - unused
-    - gosimple
-    - structcheck
-    - varcheck
-    - ineffassign
-    - deadcode
+    # - gofmt
+    # - govet
+    # - errcheck
+    # - staticcheck
+    # - unused
+    # - gosimple
+    # - ineffassign
     - typecheck
     # Additional
-    - lll
+    # - lll
     - godox
     #- gomnd
     #- goconst
@@ -240,16 +237,16 @@ linters:
     # - maligned
     # - nestif
     # - gomodguard
-    - nakedret
-    - gci
+    # - nakedret
+    # - gci
     - misspell
-    - gofumpt
-    - whitespace
-    - unconvert
+    # - gofumpt
+    # - whitespace
+    # - unconvert
     - predeclared
     - noctx
     - dogsled
-    - bodyclose
+    # - bodyclose
     - asciicheck
       #- stylecheck
       # - unparam

--- a/service/init.go
+++ b/service/init.go
@@ -686,10 +686,9 @@ func (pcf *PCF) UpdatePcfSubsriberPolicyData(slice *protos.NetworkSlice) {
 
 			for _, imsi := range slice.AddUpdatedImsis {
 				if ImsiExistInDeviceGroup(devgroup, imsi) {
-					policyData, _ := self.PcfSubscriberPolicyData[imsi]
 					// TODO policy exists, so compare and get difference with existing policy then notify the subscriber
 					self.PcfSubscriberPolicyData[imsi] = &context.PcfSubscriberPolicyData{}
-					policyData = self.PcfSubscriberPolicyData[imsi]
+					policyData := self.PcfSubscriberPolicyData[imsi]
 					policyData.CtxLog = logger.CtxLog.WithField(logger.FieldSupi, "imsi-"+imsi)
 					policyData.PccPolicy = make(map[string]*context.PccPolicy)
 					policyData.PccPolicy[sliceid] = &context.PccPolicy{make(map[string]*models.PccRule),


### PR DESCRIPTION
# Description

There was a .golangci.yml file for linting validation but it was not used in the CI. This PR adds golang lint validation in the github actions set of validations. I commented out the checks that failed. Those will be addressed carefully one at the time in future PR's as they will require some code changes. At least now we will have some linting validation. I also removed the deprecated lint checks like deadcode.