### PR TITLE
chore: Adds whitespace and gosimple lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -225,7 +225,7 @@ linters:
     - errcheck
     - staticcheck
     - unused
-    # - gosimple
+    - gosimple
     # - ineffassign
     - typecheck
     # Additional
@@ -241,7 +241,7 @@ linters:
     # - gci
     - misspell
     # - gofumpt
-    # - whitespace
+    - whitespace
     # - unconvert
     - predeclared
     - noctx

--- a/context/context.go
+++ b/context/context.go
@@ -496,7 +496,6 @@ func (c *PCFContext) DisplayPcfSubscriberPolicyData(imsi string) {
 				logger.CtxLog.Infof("     TcId: %v", t.TcId)
 				logger.CtxLog.Infof("     FlowStatus: %v", t.FlowStatus)
 			}
-
 		}
 	}
 }

--- a/service/init.go
+++ b/service/init.go
@@ -774,7 +774,6 @@ func (pcf *PCF) UpdatePcfSubsriberPolicyData(slice *protos.NetworkSlice) {
 				delete(self.PcfSubscriberPolicyData, imsi)
 			}
 		}
-
 	}
 }
 
@@ -887,7 +886,7 @@ func (pcf *PCF) updateConfig(commChannel chan *protos.NetworkSliceResponse) bool
 		// minConfig is 'true' when one slice is configured at least.
 		// minConfig is 'false' when no slice configuration.
 		// check PlmnList for each configuration update from Roc/Simapp.
-		if minConfig == false {
+		if !minConfig {
 			// For each slice Plmn is the mandatory parameter, checking PlmnList length is greater than zero
 			// setting minConfig to true
 			if len(pcfContext.PlmnList) > 0 {


### PR DESCRIPTION
# Description

Adds the `whitespace` and `gosimple` lint checks and makes the necessary changes to satisfy them.