### PR TITLE
Enable fieldalignment go vet check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -172,8 +172,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
     # enable all analyzers
     enable-all: true
-    disable:
-      - fieldalignment
   depguard:
     list-type: blacklist
     include-go-root: false

--- a/context/context.go
+++ b/context/context.go
@@ -42,7 +42,6 @@ type PCFContext struct {
 	UriScheme       models.UriScheme
 	BindingIPv4     string
 	RegisterIPv4    string
-	SBIPort         int
 	TimeFormat      string
 	DefaultBdtRefId string
 	NfService       map[models.ServiceName]models.NfService
@@ -58,14 +57,14 @@ type PCFContext struct {
 	// App Session related
 	AppSessionPool sync.Map
 	// AMF Status Change Subscription related
-	AMFStatusSubsData sync.Map // map[string]AMFStatusSubscriptionData; subscriptionID as key
+	AMFStatusSubsData       sync.Map                            // map[string]AMFStatusSubscriptionData; subscriptionID as key
+	PcfSubscriberPolicyData map[string]*PcfSubscriberPolicyData // subscriberId is key
 
+	DnnList  []string
+	PlmnList []factory.PlmnSupportItem
+	SBIPort  int
 	// lock
 	DefaultUdrURILock sync.RWMutex
-
-	DnnList                 []string
-	PlmnList                []factory.PlmnSupportItem
-	PcfSubscriberPolicyData map[string]*PcfSubscriberPolicyData // subscriberId is key
 }
 
 type SessionPolicy struct {
@@ -81,9 +80,9 @@ type PccPolicy struct {
 	IdGenerator   *idgenerator.IDGenerator
 }
 type PcfSubscriberPolicyData struct {
-	Supi      string
 	PccPolicy map[string]*PccPolicy // sst+sd is key
 	CtxLog    *logrus.Entry
+	Supi      string
 }
 
 type AMFStatusSubscriptionData struct {
@@ -93,16 +92,16 @@ type AMFStatusSubscriptionData struct {
 }
 
 type AppSessionData struct {
-	AppSessionId      string
 	AppSessionContext *models.AppSessionContext
 	// (compN/compN-subCompN/appId-%s) map to PccRule
 	RelatedPccRuleIds    map[string]string
 	PccRuleIdMapToCompId map[string]string
 	// EventSubscription
-	Events   map[models.AfEvent]models.AfNotifMethod
-	EventUri string
+	Events map[models.AfEvent]models.AfNotifMethod
 	// related Session
 	SmPolicyData *UeSmPolicyData
+	AppSessionId string
+	EventUri     string
 }
 
 // Create new PCF context

--- a/context/ue.go
+++ b/context/ue.go
@@ -20,13 +20,10 @@ import (
 // key is supi
 type UeContext struct {
 	// Ue Context
-	Supi                      string
-	Gpsi                      string
-	Pei                       string
-	GroupIds                  []string
-	PolAssociationIDGenerator uint32
-	AMPolicyData              map[string]*UeAMPolicyData // use PolAssoId(ue.Supi-numPolId) as key
-
+	Supi         string
+	Gpsi         string
+	Pei          string
+	AMPolicyData map[string]*UeAMPolicyData // use PolAssoId(ue.Supi-numPolId) as key
 	// Udr Ref
 	UdrUri string
 	// SMPolicy
@@ -41,6 +38,9 @@ type UeContext struct {
 	AppSessionIdStore           *AppSessionIdStore
 	PolicyDataSubscriptionStore *models.PolicyDataSubscription
 	PolicyDataChangeStore       *models.PolicyDataChangeNotification
+
+	GroupIds                  []string
+	PolAssociationIDGenerator uint32
 }
 
 type UeAMPolicyData struct {
@@ -55,10 +55,7 @@ type UeAMPolicyData struct {
 	Guami        *models.Guami
 	ServiveName  string
 	// TraceReq *TraceData
-	// Policy Association
-	Triggers    []models.RequestTrigger
 	ServAreaRes *models.ServiceAreaRestriction
-	Rfsp        int32
 	UserLoc     *models.UserLocation
 	TimeZone    string
 	SuppFeat    string
@@ -68,6 +65,9 @@ type UeAMPolicyData struct {
 	AmPolicyData *models.AmPolicyData // Svbscription Data
 	// Corresponding UE
 	PcfUe *UeContext
+	// Policy Association
+	Triggers []models.RequestTrigger
+	Rfsp     int32
 }
 
 type UeSmPolicyData struct {
@@ -82,9 +82,6 @@ type UeSmPolicyData struct {
 	// SmfId                  string
 	// TraceReq *TraceData
 	// RecoveryTime     *time.Time
-	PackFiltIdGenarator int32
-	PccRuleIdGenarator  int32
-	ChargingIdGenarator int32
 	// FlowMapsToPackFiltIds  map[string][]string // use Flow Description(in TS 29214) as key map to pcc rule ids
 	PackFiltMapToPccRuleId map[string]string // use PackFiltId as Key
 	// Related to GBR
@@ -98,7 +95,10 @@ type UeSmPolicyData struct {
 	// related to AppSession
 	AppSessions map[string]bool // related appSessionId
 	// Corresponding UE
-	PcfUe *UeContext
+	PcfUe               *UeContext
+	PackFiltIdGenarator int32
+	PccRuleIdGenarator  int32
+	ChargingIdGenarator int32
 }
 
 // NewUeAMPolicyData returns created UeAMPolicyData data and insert this data to Ue.AMPolicyData with assolId as key
@@ -464,8 +464,8 @@ func (ue *UeContext) SMPolicyFindByIdentifiersIpv6(v6 string, sNssai *models.Sns
 
 // AppSessionIdStore -
 type AppSessionIdStore struct {
-	AppSessionId      string
 	AppSessionContext models.AppSessionContext
+	AppSessionId      string
 }
 
 var AppSessionContextStore []AppSessionIdStore

--- a/factory/config.go
+++ b/factory/config.go
@@ -37,18 +37,18 @@ const (
 )
 
 type Configuration struct {
-	PcfName         string            `yaml:"pcfName,omitempty"`
-	Sbi             *Sbi              `yaml:"sbi,omitempty"`
-	TimeFormat      string            `yaml:"timeFormat,omitempty"`
-	DefaultBdtRefId string            `yaml:"defaultBdtRefId,omitempty"`
-	NrfUri          string            `yaml:"nrfUri,omitempty"`
-	ServiceList     []Service         `yaml:"serviceList,omitempty"`
-	PlmnList        []PlmnSupportItem `yaml:"plmnList,omitempty"`
-	Mongodb         *Mongodb          `yaml:"mongodb"`
+	PcfName         string    `yaml:"pcfName,omitempty"`
+	Sbi             *Sbi      `yaml:"sbi,omitempty"`
+	TimeFormat      string    `yaml:"timeFormat,omitempty"`
+	DefaultBdtRefId string    `yaml:"defaultBdtRefId,omitempty"`
+	NrfUri          string    `yaml:"nrfUri,omitempty"`
+	ServiceList     []Service `yaml:"serviceList,omitempty"`
+	Mongodb         *Mongodb  `yaml:"mongodb"`
 
 	/* below config received from RoC */
 	DnnList   map[string][]string // sst+sd os key
 	SlicePlmn map[string]PlmnSupportItem
+	PlmnList  []PlmnSupportItem `yaml:"plmnList,omitempty"`
 }
 
 type Service struct {

--- a/httpcallback/router.go
+++ b/httpcallback/router.go
@@ -7,7 +7,6 @@ package httpcallback
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -17,14 +16,14 @@ import (
 
 // Route is the information for every URI.
 type Route struct {
+	// HandlerFunc is the handler function of this route.
+	HandlerFunc gin.HandlerFunc
 	// Name is the name of this Route.
 	Name string
 	// Method is the string for the HTTP method. ex) GET, POST etc..
 	Method string
 	// Pattern is the pattern of the URI.
 	Pattern string
-	// HandlerFunc is the handler function of this route.
-	HandlerFunc gin.HandlerFunc
 }
 
 // Routes is the list of the generated Route.
@@ -56,23 +55,17 @@ func Index(c *gin.Context) {
 
 var routes = Routes{
 	{
-		"Index",
-		"GET",
-		"/",
-		Index,
+		Name: "Index", Method: "GET",
+		Pattern: "/", HandlerFunc: Index,
 	},
 
 	{
-		"HTTPNudrNotify",
-		strings.ToUpper("Post"),
-		"/nudr-notify/:supi",
-		HTTPNudrNotify,
+		Name: "HTTPNudrNotify", Method: "POST",
+		Pattern: "/nudr-notify/:supi", HandlerFunc: HTTPNudrNotify,
 	},
 
 	{
-		"HTTPAmfStatusChangeNotify",
-		strings.ToUpper("Post"),
-		"/amfstatus",
-		HTTPAmfStatusChangeNotify,
+		Name: "HTTPAmfStatusChangeNotify", Method: "POST",
+		Pattern: "/amfstatus", HandlerFunc: HTTPAmfStatusChangeNotify,
 	},
 }

--- a/internal/notifyevent/send_smpolicy_termination.go
+++ b/internal/notifyevent/send_smpolicy_termination.go
@@ -19,8 +19,8 @@ import (
 const SendSMpolicyTerminationNotifyEventName event.Name = "SendSMpolicyTerminationNotify"
 
 type SendSMpolicyTerminationNotifyEvent struct {
-	uri     string
 	request *models.TerminationNotification
+	uri     string
 }
 
 func (e SendSMpolicyTerminationNotifyEvent) Handle() {

--- a/internal/notifyevent/send_smpolicy_update.go
+++ b/internal/notifyevent/send_smpolicy_update.go
@@ -19,8 +19,8 @@ import (
 const SendSMpolicyUpdateNotifyEventName event.Name = "SendSMpolicyUpdateNotify"
 
 type SendSMpolicyUpdateNotifyEvent struct {
-	uri     string
 	request *models.SmPolicyNotification
+	uri     string
 }
 
 func (e SendSMpolicyUpdateNotifyEvent) Handle() {


### PR DESCRIPTION
Enable fieldalignment go vet check in CI
fieldalignment defines an Analyzer that detects structs that would use less memory if their fields were sorted.