### PR TITLE
chore: Move http_wrapper dependency to util project

### DIFF
--- a/ampolicy/api_default.go
+++ b/ampolicy/api_default.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -28,7 +28,7 @@ import (
 )
 
 func HTTPPoliciesPolAssoIdDelete(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["polAssoId"], _ = c.Params.Get("polAssoId")
 
 	rsp := producer.HandleDeletePoliciesPolAssoId(req)
@@ -49,7 +49,7 @@ func HTTPPoliciesPolAssoIdDelete(c *gin.Context) {
 
 // HTTPPoliciesPolAssoIdGet -
 func HTTPPoliciesPolAssoIdGet(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["polAssoId"], _ = c.Params.Get("polAssoId")
 
 	rsp := producer.HandleGetPoliciesPolAssoId(req)
@@ -98,7 +98,7 @@ func HTTPPoliciesPolAssoIdUpdatePost(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, policyAssociationUpdateRequest)
+	req := httpwrapper.NewRequest(c.Request, policyAssociationUpdateRequest)
 	req.Params["polAssoId"], _ = c.Params.Get("polAssoId")
 
 	rsp := producer.HandleUpdatePostPoliciesPolAssoId(req)
@@ -154,7 +154,7 @@ func HTTPPoliciesPost(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, policyAssociationRequest)
+	req := httpwrapper.NewRequest(c.Request, policyAssociationRequest)
 	req.Params["polAssoId"], _ = c.Params.Get("polAssoId")
 
 	rsp := producer.HandlePostPolicies(req)

--- a/bdtpolicy/api_bdt_policies_collection_routers.go
+++ b/bdtpolicy/api_bdt_policies_collection_routers.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -57,7 +57,7 @@ func HTTPCreateBDTPolicy(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, bdtReqData)
+	req := httpwrapper.NewRequest(c.Request, bdtReqData)
 	rsp := producer.HandleCreateBDTPolicyContextRequest(req)
 	// step 5: response
 	for key, val := range rsp.Header { // header response is optional

--- a/bdtpolicy/api_individual_bdt_policy_document_routers.go
+++ b/bdtpolicy/api_individual_bdt_policy_document_routers.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -28,7 +28,7 @@ import (
 
 // GetBDTPolicy - Read an Individual BDT policy
 func HTTPGetBDTPolicy(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["bdtPolicyId"] = c.Params.ByName("bdtPolicyId")
 
 	rsp := producer.HandleGetBDTPolicyContextRequest(req)
@@ -78,7 +78,7 @@ func HTTPUpdateBDTPolicy(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, bdtPolicyDataPatch)
+	req := httpwrapper.NewRequest(c.Request, bdtPolicyDataPatch)
 	req.Params["bdtPolicyId"] = c.Params.ByName("bdtPolicyId")
 
 	rsp := producer.HandleUpdateBDTPolicyContextProcedure(req)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/omec-project/MongoDBLibrary v1.1.3
 	github.com/omec-project/config5g v1.2.0
 	github.com/omec-project/http2_util v1.1.0
-	github.com/omec-project/http_wrapper v1.1.0
 	github.com/omec-project/logger_conf v1.1.0
 	github.com/omec-project/logger_util v1.1.0
 	github.com/omec-project/openapi v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,6 @@ github.com/omec-project/config5g v1.2.0 h1:fyIg+1LZ9jn8DTkVUbD4jyxA4FgMICdIBwZVn
 github.com/omec-project/config5g v1.2.0/go.mod h1:AWFzCbbgCBx/iJwt+zWbpDGLHRpFzg24OYHqIkdcMVA=
 github.com/omec-project/http2_util v1.1.0 h1:8H2NME/V8iONth8TlyK/3w4pguAzaeUnEv9pmeAocwQ=
 github.com/omec-project/http2_util v1.1.0/go.mod h1:QwoZRaUyhEp/kTEqXvf0gCYtfQrNHBdkVw939vsMjZY=
-github.com/omec-project/http_wrapper v1.1.0 h1:2hD8RUaR/VVg3tUUfuxsuo1/JNpZLiAE8IvATGqDME4=
-github.com/omec-project/http_wrapper v1.1.0/go.mod h1:mc045fjVVJ0/q0g4QG4nuSC0N1BIqGR/ZoK76XgifVU=
 github.com/omec-project/logger_conf v1.1.0 h1:C0/HbsSOWV8D3/lm7Iqe1nUL9ltVtVO4MDC9ZxIo/xc=
 github.com/omec-project/logger_conf v1.1.0/go.mod h1:2+SOX9OFbPZ+UNv8k+tvPnaWHo4CuX5G/x12dz5sWUE=
 github.com/omec-project/logger_util v1.1.0 h1:R7tT80+ML1HlK4OoTrNv/UK+2H/u2GdIFNBx41g630Q=

--- a/httpcallback/amf_status_change_notify.go
+++ b/httpcallback/amf_status_change_notify.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func HTTPAmfStatusChangeNotify(c *gin.Context) {
@@ -47,7 +47,7 @@ func HTTPAmfStatusChangeNotify(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, amfStatusChangeNotification)
+	req := httpwrapper.NewRequest(c.Request, amfStatusChangeNotification)
 
 	rsp := producer.HandleAmfStatusChangeNotify(req)
 

--- a/httpcallback/sm_policy_notify.go
+++ b/httpcallback/sm_policy_notify.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // Nudr-Notify-smpolicy
@@ -47,7 +47,7 @@ func HTTPNudrNotify(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, policyDataChangeNotification)
+	req := httpwrapper.NewRequest(c.Request, policyDataChangeNotification)
 	req.Params["ReqURI"] = c.Params.ByName("supi")
 
 	rsp := producer.HandleSmPolicyNotify(req)

--- a/oam/api_get_am_policy.go
+++ b/oam/api_get_am_policy.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -27,7 +27,7 @@ func setCorsHeader(c *gin.Context) {
 func HTTPOAMGetAmPolicy(c *gin.Context) {
 	setCorsHeader(c)
 
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["supi"] = c.Params.ByName("supi")
 
 	rsp := producer.HandleOAMGetAmPolicyRequest(req)

--- a/policyauthorization/api_application_sessions_collection.go
+++ b/policyauthorization/api_application_sessions_collection.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -66,7 +66,7 @@ func HTTPPostAppSessions(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, appSessionContext)
+	req := httpwrapper.NewRequest(c.Request, appSessionContext)
 	rsp := producer.HandlePostAppSessionsContext(req)
 
 	for key, val := range rsp.Header {

--- a/policyauthorization/api_events_subscription_document.go
+++ b/policyauthorization/api_events_subscription_document.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -29,7 +29,7 @@ import (
 
 // HTTPDeleteEventsSubsc - deletes the Events Subscription subresource
 func HTTPDeleteEventsSubsc(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["appSessionId"], _ = c.Params.Get("appSessionId")
 
 	rsp := producer.HandleDeleteEventsSubscContext(req)
@@ -85,7 +85,7 @@ func HTTPUpdateEventsSubsc(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, eventsSubscReqData)
+	req := httpwrapper.NewRequest(c.Request, eventsSubscReqData)
 	req.Params["appSessionId"], _ = c.Params.Get("appSessionId")
 
 	rsp := producer.HandleUpdateEventsSubscContext(req)

--- a/policyauthorization/api_individual_application_session_context_document.go
+++ b/policyauthorization/api_individual_application_session_context_document.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -59,7 +59,7 @@ func HTTPDeleteAppSession(c *gin.Context) {
 		}
 	}
 
-	req := http_wrapper.NewRequest(c.Request, eventsSubscReqData)
+	req := httpwrapper.NewRequest(c.Request, eventsSubscReqData)
 	req.Params["appSessionId"], _ = c.Params.Get("appSessionId")
 
 	rsp := producer.HandleDeleteAppSessionContext(req)
@@ -80,7 +80,7 @@ func HTTPDeleteAppSession(c *gin.Context) {
 
 // HTTPGetAppSession - Reads an existing Individual Application Session Context
 func HTTPGetAppSession(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["appSessionId"], _ = c.Params.Get("appSessionId")
 
 	rsp := producer.HandleGetAppSessionContext(req)
@@ -129,7 +129,7 @@ func HTTPModAppSession(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, appSessionContextUpdateData)
+	req := httpwrapper.NewRequest(c.Request, appSessionContextUpdateData)
 	req.Params["appSessionId"], _ = c.Params.Get("appSessionId")
 
 	rsp := producer.HandleModAppSessionContext(req)

--- a/producer/ampolicy.go
+++ b/producer/ampolicy.go
@@ -13,25 +13,25 @@ import (
 
 	"github.com/mohae/deepcopy"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/consumer"
 	pcf_context "github.com/omec-project/pcf/context"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
-func HandleDeletePoliciesPolAssoId(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDeletePoliciesPolAssoId(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.AMpolicylog.Infof("Handle AM Policy Association Delete")
 
 	polAssoId := request.Params["polAssoId"]
 
 	problemDetails := DeletePoliciesPolAssoIdProcedure(polAssoId)
 	if problemDetails == nil {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	} else {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 }
 
@@ -46,22 +46,22 @@ func DeletePoliciesPolAssoIdProcedure(polAssoId string) *models.ProblemDetails {
 }
 
 // PoliciesPolAssoIdGet -
-func HandleGetPoliciesPolAssoId(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetPoliciesPolAssoId(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.AMpolicylog.Infof("Handle AM Policy Association Get")
 
 	polAssoId := request.Params["polAssoId"]
 
 	response, problemDetails := GetPoliciesPolAssoIdProcedure(polAssoId)
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+	return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 }
 
 func GetPoliciesPolAssoIdProcedure(polAssoId string) (*models.PolicyAssociation, *models.ProblemDetails) {
@@ -92,7 +92,7 @@ func GetPoliciesPolAssoIdProcedure(polAssoId string) (*models.PolicyAssociation,
 	return &rsp, nil
 }
 
-func HandleUpdatePostPoliciesPolAssoId(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdatePostPoliciesPolAssoId(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.AMpolicylog.Infof("Handle AM Policy Association Update")
 
 	polAssoId := request.Params["polAssoId"]
@@ -100,15 +100,15 @@ func HandleUpdatePostPoliciesPolAssoId(request *http_wrapper.Request) *http_wrap
 
 	response, problemDetails := UpdatePostPoliciesPolAssoIdProcedure(polAssoId, policyAssociationUpdateRequest)
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+	return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 }
 
 func UpdatePostPoliciesPolAssoIdProcedure(polAssoId string,
@@ -184,7 +184,7 @@ func UpdatePostPoliciesPolAssoIdProcedure(polAssoId string,
 }
 
 // Create AM Policy
-func HandlePostPolicies(request *http_wrapper.Request) *http_wrapper.Response {
+func HandlePostPolicies(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.AMpolicylog.Infof("Handle AM Policy Create Request")
 
 	polAssoId := request.Params["polAssoId"]
@@ -195,15 +195,15 @@ func HandlePostPolicies(request *http_wrapper.Request) *http_wrapper.Response {
 		"Location": {locationHeader},
 	}
 	if response != nil {
-		return http_wrapper.NewResponse(http.StatusCreated, headers, response)
+		return httpwrapper.NewResponse(http.StatusCreated, headers, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+	return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 }
 
 func PostPoliciesProcedure(polAssoId string,

--- a/producer/bdtpolicy.go
+++ b/producer/bdtpolicy.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/mohae/deepcopy"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
 	"github.com/omec-project/openapi/Nudr_DataRepository"
 	"github.com/omec-project/openapi/models"
@@ -22,9 +21,10 @@ import (
 	pcf_context "github.com/omec-project/pcf/context"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
-func HandleGetBDTPolicyContextRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetBDTPolicyContextRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.Bdtpolicylog.Infof("Handle GetBDTPolicyContext")
 
@@ -37,15 +37,15 @@ func HandleGetBDTPolicyContextRequest(request *http_wrapper.Request) *http_wrapp
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getBDTPolicyContextProcedure(bdtPolicyID string) (
@@ -64,7 +64,7 @@ func getBDTPolicyContextProcedure(bdtPolicyID string) (
 }
 
 // UpdateBDTPolicy - Update an Individual BDT policy (choose policy data)
-func HandleUpdateBDTPolicyContextProcedure(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdateBDTPolicyContextProcedure(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.Bdtpolicylog.Infof("Handle UpdateBDTPolicyContext")
 
@@ -78,15 +78,15 @@ func HandleUpdateBDTPolicyContextProcedure(request *http_wrapper.Request) *http_
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func updateBDTPolicyContextProcedure(request models.BdtPolicyDataPatch, bdtPolicyID string) (
@@ -145,7 +145,7 @@ func updateBDTPolicyContextProcedure(request models.BdtPolicyDataPatch, bdtPolic
 }
 
 // CreateBDTPolicy - Create a new Individual BDT policy
-func HandleCreateBDTPolicyContextRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleCreateBDTPolicyContextRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.Bdtpolicylog.Infof("Handle CreateBDTPolicyContext")
 
@@ -158,11 +158,11 @@ func HandleCreateBDTPolicyContextRequest(request *http_wrapper.Request) *http_wr
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusCreated, header, response)
+		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNotFound, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNotFound, nil, nil)
 	}
 }
 

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -8,19 +8,19 @@ package producer
 import (
 	"net/http"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
+	"github.com/omec-project/util/httpwrapper"
 )
 
-func HandleAmfStatusChangeNotify(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleAmfStatusChangeNotify(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CallbackLog.Warnf("[PCF] Handle Amf Status Change Notify is not implemented.")
 
 	notification := request.Body.(models.AmfStatusChangeNotification)
 
 	AmfStatusChangeNotifyProcedure(notification)
 
-	return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+	return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 }
 
 // TODO: handle AMF Status Change Notify
@@ -28,7 +28,7 @@ func AmfStatusChangeNotifyProcedure(notification models.AmfStatusChangeNotificat
 	logger.CallbackLog.Debugf("receive AMF status change notification[%+v]", notification)
 }
 
-func HandleSmPolicyNotify(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleSmPolicyNotify(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.CallbackLog.Warnf("[PCF] Handle Sm Policy Notify is not implemented.")
 
 	notification := request.Body.(models.PolicyDataChangeNotification)
@@ -36,7 +36,7 @@ func HandleSmPolicyNotify(request *http_wrapper.Request) *http_wrapper.Response 
 
 	SmPolicyNotifyProcedure(supi, notification)
 
-	return http_wrapper.NewResponse(http.StatusNotImplemented, nil, nil)
+	return httpwrapper.NewResponse(http.StatusNotImplemented, nil, nil)
 }
 
 // TODO: handle SM Policy Notify

--- a/producer/oam.go
+++ b/producer/oam.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/context"
 	"github.com/omec-project/pcf/logger"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 type UEAmPolicy struct {
@@ -28,7 +28,7 @@ type UEAmPolicy struct {
 
 type UEAmPolicys []UEAmPolicy
 
-func HandleOAMGetAmPolicyRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleOAMGetAmPolicyRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.OamLog.Infof("Handle OAMGetAmPolicy")
 
@@ -41,15 +41,15 @@ func HandleOAMGetAmPolicyRequest(request *http_wrapper.Request) *http_wrapper.Re
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func OAMGetAmPolicyProcedure(supi string) (response *UEAmPolicys, problemDetails *models.ProblemDetails) {

--- a/producer/policyauthorization.go
+++ b/producer/policyauthorization.go
@@ -15,13 +15,13 @@ import (
 
 	"github.com/cydev/zero"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	pcf_context "github.com/omec-project/pcf/context"
 	"github.com/omec-project/pcf/internal/notifyevent"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func transferAfRoutReqRmToAfRoutReq(AfRoutReqRm *models.AfRoutingRequirementRm) *models.AfRoutingRequirement {
@@ -129,7 +129,7 @@ func handleMediaSubComponent(smPolicy *pcf_context.UeSmPolicyData, medComp *mode
 // Subscription to resources allocation outcome (DONE)
 // Invocation of Multimedia Priority Services (TODO)
 // Support of content versioning (TODO)
-func HandlePostAppSessionsContext(request *http_wrapper.Request) *http_wrapper.Response {
+func HandlePostAppSessionsContext(request *httpwrapper.Request) *httpwrapper.Response {
 	logger.PolicyAuthorizationlog.Traceln("Handle Create AppSessions")
 
 	appSessCtx := request.Body.(models.AppSessionContext)
@@ -140,15 +140,15 @@ func HandlePostAppSessionsContext(request *http_wrapper.Request) *http_wrapper.R
 		headers := http.Header{
 			"Location": {locationHeader},
 		}
-		return http_wrapper.NewResponse(http.StatusCreated, headers, response)
+		return httpwrapper.NewResponse(http.StatusCreated, headers, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+	return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 }
 
 func postAppSessCtxProcedure(appSessCtx *models.AppSessionContext) (*models.AppSessionContext,
@@ -432,16 +432,16 @@ func postAppSessCtxProcedure(appSessCtx *models.AppSessionContext) (*models.AppS
 }
 
 // HandleDeleteAppSession - Deletes an existing Individual Application Session Context
-func HandleDeleteAppSessionContext(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDeleteAppSessionContext(request *httpwrapper.Request) *httpwrapper.Response {
 	eventsSubscReqData := request.Body.(*models.EventsSubscReqData)
 	appSessID := request.Params["appSessionId"]
 	logger.PolicyAuthorizationlog.Infof("Handle Del AppSessions, AppSessionId[%s]", appSessID)
 
 	problemDetails := DeleteAppSessionContextProcedure(appSessID, eventsSubscReqData)
 	if problemDetails == nil {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	} else {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 }
 
@@ -500,15 +500,15 @@ func DeleteAppSessionContextProcedure(appSessID string,
 }
 
 // HandleGetAppSession - Reads an existing Individual Application Session Context
-func HandleGetAppSessionContext(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetAppSessionContext(request *httpwrapper.Request) *httpwrapper.Response {
 	appSessID := request.Params["appSessionId"]
 	logger.PolicyAuthorizationlog.Infof("Handle Get AppSessions, AppSessionId[%s]", appSessID)
 
 	problemDetails, response := GetAppSessionContextProcedure(appSessID)
 	if problemDetails == nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 }
 
@@ -528,16 +528,16 @@ func GetAppSessionContextProcedure(appSessID string) (*models.ProblemDetails, *m
 }
 
 // HandleModAppSession - Modifies an existing Individual Application Session Context
-func HandleModAppSessionContext(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleModAppSessionContext(request *httpwrapper.Request) *httpwrapper.Response {
 	appSessID := request.Params["appSessionId"]
 	ascUpdateData := request.Body.(models.AppSessionContextUpdateData)
 	logger.PolicyAuthorizationlog.Infof("Handle Modify AppSessions, AppSessionId[%s]", appSessID)
 
 	problemDetails, response := ModAppSessionContextProcedure(appSessID, ascUpdateData)
 	if problemDetails == nil {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 }
 
@@ -811,15 +811,15 @@ func ModAppSessionContextProcedure(appSessID string,
 }
 
 // HandleDeleteEventsSubsc - deletes the Events Subscription subresource
-func HandleDeleteEventsSubscContext(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDeleteEventsSubscContext(request *httpwrapper.Request) *httpwrapper.Response {
 	appSessID := request.Params["appSessID"]
 	logger.PolicyAuthorizationlog.Tracef("Handle Del AppSessions Events Subsc, AppSessionId[%s]", appSessID)
 
 	problemDetails := DeleteEventsSubscContextProcedure(appSessID)
 	if problemDetails == nil {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	} else {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 }
 
@@ -857,29 +857,29 @@ func DeleteEventsSubscContextProcedure(appSessID string) *models.ProblemDetails 
 }
 
 // HandleUpdateEventsSubsc - creates or modifies an Events Subscription subresource
-func HandleUpdateEventsSubscContext(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdateEventsSubscContext(request *httpwrapper.Request) *httpwrapper.Response {
 	EventsSubscReqData := request.Body.(models.EventsSubscReqData)
 	appSessID := request.Params["appSessID"]
 	logger.PolicyAuthorizationlog.Tracef("Handle Put AppSessions Events Subsc, AppSessionId[%s]", appSessID)
 
 	response, locationHeader, status, problemDetails := UpdateEventsSubscContextProcedure(appSessID, EventsSubscReqData)
 	if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else if status == http.StatusCreated {
 		headers := http.Header{
 			"Location": {locationHeader},
 		}
-		return http_wrapper.NewResponse(http.StatusCreated, headers, response)
+		return httpwrapper.NewResponse(http.StatusCreated, headers, response)
 	} else if status == http.StatusOK {
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if status == http.StatusNoContent {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, response)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, response)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+	return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 }
 
 func SendAppSessionEventNotification(appSession *pcf_context.AppSessionData, request models.EventsNotification) {

--- a/producer/smpolicy.go
+++ b/producer/smpolicy.go
@@ -16,17 +16,17 @@ import (
 	"github.com/antihax/optional"
 	"github.com/mohae/deepcopy"
 
-	"github.com/omec-project/http_wrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/Nudr_DataRepository"
 	"github.com/omec-project/openapi/models"
 	pcf_context "github.com/omec-project/pcf/context"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // SmPoliciesPost -
-func HandleCreateSmPolicyRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleCreateSmPolicyRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SMpolicylog.Infof("Handle CreateSmPolicy")
 	// step 2: retrieve request
@@ -38,11 +38,11 @@ func HandleCreateSmPolicyRequest(request *http_wrapper.Request) *http_wrapper.Re
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusCreated, header, response)
+		return httpwrapper.NewResponse(http.StatusCreated, header, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNotFound, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNotFound, nil, nil)
 	}
 }
 
@@ -286,7 +286,7 @@ func createSMPolicyProcedure(request models.SmPolicyContextData) (
 }
 
 // SmPoliciessmPolicyIDDeletePost -
-func HandleDeleteSmPolicyContextRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleDeleteSmPolicyContextRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SMpolicylog.Infof("Handle DeleteSmPolicyContext")
 
@@ -299,9 +299,9 @@ func HandleDeleteSmPolicyContextRequest(request *http_wrapper.Request) *http_wra
 	// step 4: process the return value from step 3
 	if problemDetails != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	} else {
-		return http_wrapper.NewResponse(http.StatusNoContent, nil, nil)
+		return httpwrapper.NewResponse(http.StatusNoContent, nil, nil)
 	}
 }
 
@@ -339,7 +339,7 @@ func deleteSmPolicyContextProcedure(smPolicyID string) *models.ProblemDetails {
 }
 
 // SmPoliciessmPolicyIDGet -
-func HandleGetSmPolicyContextRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleGetSmPolicyContextRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SMpolicylog.Infof("Handle GetSmPolicyContext")
 
@@ -351,15 +351,15 @@ func HandleGetSmPolicyContextRequest(request *http_wrapper.Request) *http_wrappe
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func getSmPolicyContextProcedure(smPolicyID string) (
@@ -382,7 +382,7 @@ func getSmPolicyContextProcedure(smPolicyID string) (
 }
 
 // SmPoliciessmPolicyIDUpdatePost -
-func HandleUpdateSmPolicyContextRequest(request *http_wrapper.Request) *http_wrapper.Response {
+func HandleUpdateSmPolicyContextRequest(request *httpwrapper.Request) *httpwrapper.Response {
 	// step 1: log
 	logger.SMpolicylog.Infof("Handle UpdateSmPolicyContext")
 
@@ -396,15 +396,15 @@ func HandleUpdateSmPolicyContextRequest(request *http_wrapper.Request) *http_wra
 	// step 4: process the return value from step 3
 	if response != nil {
 		// status code is based on SPEC, and option headers
-		return http_wrapper.NewResponse(http.StatusOK, nil, response)
+		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	} else if problemDetails != nil {
-		return http_wrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
+		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 	problemDetails = &models.ProblemDetails{
 		Status: http.StatusForbidden,
 		Cause:  "UNSPECIFIED",
 	}
-	return http_wrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
+	return httpwrapper.NewResponse(http.StatusForbidden, nil, problemDetails)
 }
 
 func updateSmPolicyContextProcedure(request models.SmPolicyUpdateContextData, smPolicyID string) (

--- a/smpolicy/api_default.go
+++ b/smpolicy/api_default.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/http_wrapper"
+	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
@@ -57,7 +57,7 @@ func HTTPSmPoliciesPost(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, smPolicyContextData)
+	req := httpwrapper.NewRequest(c.Request, smPolicyContextData)
 	rsp := producer.HandleCreateSmPolicyRequest(req)
 
 	// step 5: response
@@ -80,7 +80,7 @@ func HTTPSmPoliciesPost(c *gin.Context) {
 
 // SmPoliciesSmPolicyIdDeletePost -
 func HTTPSmPoliciesSmPolicyIdDeletePost(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["smPolicyId"] = c.Params.ByName("smPolicyId")
 
 	rsp := producer.HandleDeleteSmPolicyContextRequest(req)
@@ -101,7 +101,7 @@ func HTTPSmPoliciesSmPolicyIdDeletePost(c *gin.Context) {
 
 // SmPoliciesSmPolicyIdGet -
 func HTTPSmPoliciesSmPolicyIDGet(c *gin.Context) {
-	req := http_wrapper.NewRequest(c.Request, nil)
+	req := httpwrapper.NewRequest(c.Request, nil)
 	req.Params["smPolicyId"] = c.Params.ByName("smPolicyId")
 
 	rsp := producer.HandleGetSmPolicyContextRequest(req)
@@ -151,7 +151,7 @@ func HTTPSmPoliciesSmPolicyIdUpdatePost(c *gin.Context) {
 		return
 	}
 
-	req := http_wrapper.NewRequest(c.Request, smPolicyUpdateContextData)
+	req := httpwrapper.NewRequest(c.Request, smPolicyUpdateContextData)
 	req.Params["smPolicyId"] = c.Params.ByName("smPolicyId")
 
 	rsp := producer.HandleUpdateSmPolicyContextRequest(req)


### PR DESCRIPTION
Moves the `http_wrapper` dependency to the `util` project. Tested with a successful `gnbsim` simulation.