### PR TITLE
chore: Move path_util dependency to util project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,7 @@ require (
 	github.com/omec-project/logger_conf v1.1.0
 	github.com/omec-project/logger_util v1.1.0
 	github.com/omec-project/openapi v1.1.0
-	github.com/omec-project/path_util v1.1.0
-	github.com/omec-project/util v1.0.12
+	github.com/omec-project/util v1.0.13-0.20240207024358-eb30f7e970e8
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	github.com/tim-ywliu/event v0.1.0
@@ -52,6 +51,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
+	github.com/omec-project/path_util v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/omec-project/openapi v1.1.0 h1:N3v59+FM2V/eCv2Au10kbyeTf1DsScJkEdkDEc
 github.com/omec-project/openapi v1.1.0/go.mod h1:Fv9ajWROYypcNER+ZwWXPhLCdV4pBz75KqFp/R/2gCw=
 github.com/omec-project/path_util v1.1.0 h1:vzzLsay8+uexyYEqS06th8lMcwp+N+CXcaHhaypZn1Q=
 github.com/omec-project/path_util v1.1.0/go.mod h1:O1ch35al6+FXKmg6+5vOpKusl4fiB0u36oYjxwI4QK4=
-github.com/omec-project/util v1.0.12 h1:fmeeUxexHdi4nipAJumaq4lcx9l83FPaNfGH2fRmTTw=
-github.com/omec-project/util v1.0.12/go.mod h1:Cn9P57qYFiEu0ZXti8imODsJIXVGqnqhP40MwbVbo3g=
+github.com/omec-project/util v1.0.13-0.20240207024358-eb30f7e970e8 h1:xjfHzmCE5l0JrSPJ56YEeGH9ZP+u6z6zV0atnQn/MEI=
+github.com/omec-project/util v1.0.13-0.20240207024358-eb30f7e970e8/go.mod h1:Cn9P57qYFiEu0ZXti8imODsJIXVGqnqhP40MwbVbo3g=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=

--- a/service/init.go
+++ b/service/init.go
@@ -30,8 +30,6 @@ import (
 	"github.com/omec-project/logger_util"
 	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
 	"github.com/omec-project/openapi/models"
-	"github.com/omec-project/path_util"
-	pathUtilLogger "github.com/omec-project/path_util/logger"
 	"github.com/omec-project/pcf/ampolicy"
 	"github.com/omec-project/pcf/bdtpolicy"
 	"github.com/omec-project/pcf/consumer"
@@ -46,6 +44,8 @@ import (
 	"github.com/omec-project/pcf/uepolicy"
 	"github.com/omec-project/pcf/util"
 	"github.com/omec-project/util/idgenerator"
+	"github.com/omec-project/util/path_util"
+	pathUtilLogger "github.com/omec-project/util/path_util/logger"
 )
 
 type PCF struct{}

--- a/util/pcf_util.go
+++ b/util/pcf_util.go
@@ -19,9 +19,9 @@ import (
 	"github.com/omec-project/openapi/Npcf_SMPolicyControl"
 	"github.com/omec-project/openapi/Nudr_DataRepository"
 	"github.com/omec-project/openapi/models"
-	"github.com/omec-project/path_util"
 	"github.com/omec-project/pcf/context"
 	"github.com/omec-project/pcf/logger"
+	"github.com/omec-project/util/path_util"
 )
 
 const TimeFormat = time.RFC3339


### PR DESCRIPTION
Moves the `path_util` dependency to the `util` project. Tested with a successful `gnbsim` simulation.