### PR TITLE
chore: Parameterise webui url

### DIFF
--- a/factory/config.go
+++ b/factory/config.go
@@ -42,6 +42,7 @@ type Configuration struct {
 	TimeFormat      string    `yaml:"timeFormat,omitempty"`
 	DefaultBdtRefId string    `yaml:"defaultBdtRefId,omitempty"`
 	NrfUri          string    `yaml:"nrfUri,omitempty"`
+	WebuiUri        string    `yaml:"webuiUri"`
 	ServiceList     []Service `yaml:"serviceList,omitempty"`
 	Mongodb         *Mongodb  `yaml:"mongodb"`
 

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -30,6 +30,9 @@ func InitConfigFactory(f string) error {
 		if yamlErr := yaml.Unmarshal(content, &PcfConfig); yamlErr != nil {
 			return yamlErr
 		}
+		if PcfConfig.Configuration.WebuiUri == "" {
+			PcfConfig.Configuration.WebuiUri = "webui:9876"
+		}
 	}
 
 	return nil

--- a/factory/pcf_config_test.go
+++ b/factory/pcf_config_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024 Canonical Ltd.
+/*
+ *  Tests for PCF Configuration Factory
+ */
+
+package factory
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Webui URL is not set then default Webui URL value is returned
+func TestGetDefaultWebuiUrl(t *testing.T) {
+	if err := InitConfigFactory("pcfcfg.yaml"); err != nil {
+		fmt.Printf("Error in InitConfigFactory: %v\n", err)
+	}
+	got := PcfConfig.Configuration.WebuiUri
+	want := "webui:9876"
+	assert.Equal(t, got, want, "The webui URL is not correct.")
+}
+
+// Webui URL is set to a custom value then custom Webui URL is returned
+func TestGetCustomWebuiUrl(t *testing.T) {
+	if err := InitConfigFactory("pcfcfg_with_custom_webui_url.yaml"); err != nil {
+		fmt.Printf("Error in InitConfigFactory: %v\n", err)
+	}
+	got := PcfConfig.Configuration.WebuiUri
+	want := "myspecialwebui:9872"
+	assert.Equal(t, got, want, "The webui URL is not correct.")
+}

--- a/factory/pcfcfg.yaml
+++ b/factory/pcfcfg.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 Canonical Ltd.
+
+configuration:
+  defaultBdtRefId: BdtPolicyId-
+  mongodb:
+    name: free5gc
+    url: http://1.1.1.1
+  nrfUri: https://nrf:443
+  pcfName: PCF
+info:
+  description: PCF initial local configuration
+  version: 1.0.0

--- a/factory/pcfcfg_with_custom_webui_url.yaml
+++ b/factory/pcfcfg_with_custom_webui_url.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 Canonical Ltd.
+
+configuration:
+  defaultBdtRefId: BdtPolicyId-
+  mongodb:
+    name: free5gc
+    url: http://1.1.1.1
+  nrfUri: https://nrf:443
+  webuiUri: myspecialwebui:9872 # a valid URI of Webui
+  pcfName: PCF
+info:
+  description: PCF initial local configuration
+  version: 1.0.0

--- a/service/init.go
+++ b/service/init.go
@@ -114,7 +114,7 @@ func (pcf *PCF) Initialize(c *cli.Context) error {
 	roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 	if roc == "true" {
 		initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-		gClient := client.ConnectToConfigServer("webui:9876")
+		gClient := client.ConnectToConfigServer(factory.PcfConfig.Configuration.WebuiUri)
 		commChannel := gClient.PublishOnConfigChange(true)
 		go pcf.updateConfig(commChannel)
 	} else {


### PR DESCRIPTION
- The Webui url is hardcoded in network function services. This PR makes Webui url changeable having an entry in the configuration file.
- Adding unit test to validate that custom Webui URL is successfully set.