### PR TITLE
Enable linters and add GO report card

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -221,15 +221,14 @@ linters:
     - staticcheck
     - unused
     - gosimple
-    # - ineffassign
+    - ineffassign
     - typecheck
     # Additional
     # - lll
     - godox
     #- gomnd
-    #- goconst
+    - goconst
     # - gocognit
-    # - maligned
     # - nestif
     # - gomodguard
     # - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -234,7 +234,7 @@ linters:
     # - nakedret
     - gci
     - misspell
-    # - gofumpt
+    - gofumpt
     - whitespace
     # - unconvert
     - predeclared

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -236,7 +236,7 @@ linters:
     - misspell
     - gofumpt
     - whitespace
-    # - unconvert
+    - unconvert
     - predeclared
     - noctx
     - dogsled
@@ -244,7 +244,7 @@ linters:
     - asciicheck
       #- stylecheck
       # - unparam
-      #- wsl
+      # - wsl
 
   #disable-all: false
   fast: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -232,7 +232,7 @@ linters:
     # - nestif
     # - gomodguard
     # - nakedret
-    # - gci
+    - gci
     - misspell
     # - gofumpt
     - whitespace

--- a/README.md
+++ b/README.md
@@ -3,40 +3,46 @@ SPDX-FileCopyrightText: 2021 Open Networking Foundation <info@opennetworking.org
 Copyright 2019 free5GC.org
 
 SPDX-License-Identifier: Apache-2.0
-
 -->
+[![Go Report Card](https://goreportcard.com/badge/github.com/omec-project/pcf)](https://goreportcard.com/report/github.com/omec-project/pcf)
 
 # pcf
 
-The Policy Control Function (PCF) supports unified policy framework to govern network behaviour, 
-provides policy rules to Control Plane function(s) to enforce them and Accesses subscription information
-relevant for policy decisions in a Unified Data Repository (UDR)
+The Policy Control Function (PCF) supports unified policy framework to govern
+network behaviour, provides policy rules to Control Plane function(s) to enforce
+them and Accesses subscription information relevant for policy decisions in a
+Unified Data Repository (UDR)
 
 The reference 3GPP specification for PCF are as follows
 - PCC framework Specification 23.503,
 - Session Management Policy Control - Specification 29.512
-- Policy and Charging Control signalling flows and QoS parameter mapping- Specification 29513
+- Policy and Charging Control signalling flows and QoS parameter mapping (Spec 29.513)
 
 
 ## PCF Block Diagram
 ![PCF Block Diagram](/docs/images/README-PCF.png)
 
 ## Supported Features
-- PCF provides Access and Mobility Management related policies to the AMF Subscription Data retrieval and AM Policy management
-- PCF provides Session Management Policy Control Service to the SMF Subscription Data retrieval and SM Policy management
-- Policy Control Function (PCF) shall support interactions with the access and mobility policy enforcement in the AMF, through service-based interfaces
+- PCF provides Access and Mobility Management related policies to the AMF
+Subscription Data retrieval and AM Policy management
+- PCF provides Session Management Policy Control Service to the SMF Subscription
+Data retrieval and SM Policy management
+- Policy Control Function (PCF) shall support interactions with the access and
+mobility policy enforcement in the AMF, through service-based interfaces
 
 ## Upcoming Changes in PCF
-- Process configuration received from Configuration Service and prepare PCC Rules, Session Rules and Qos Flows 
+- Process configuration received from Configuration Service and prepare PCC
+Rules, Session Rules and Qos Flows
 - Send PCC Rules, Session Rules to SMF when a SMF Creates Policy subscriber
-- Send notification towards SMF PDU Session when PCF detects any changes in Subscriber’s Rule/Qos information.
-- Dedicated QoS flows addition  & removal through APIs
+- Send notification towards SMF PDU Session when PCF detects any changes in
+Subscriber’s Rule/Qos information.
+- Dedicated QoS flows addition and removal through APIs
 
 
 
-Compliance of the 5G Network functions can be found at [5G Compliance ](https://docs.sd-core.opennetworking.org/master/overview/3gpp-compliance-5g.html)
+Compliance of the 5G Network functions can be found at [5G Compliance](https://docs.sd-core.opennetworking.org/master/overview/3gpp-compliance-5g.html)
 
-## Reach out to us thorugh 
+## Reach out to us thorugh
 
 1. #sdcore-dev channel in [ONF Community Slack](https://onf-community.slack.com/)
 2. Raise Github issues

--- a/ampolicy/api_default.go
+++ b/ampolicy/api_default.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/ampolicy/api_default.go
+++ b/ampolicy/api_default.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
 	"github.com/omec-project/pcf/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func HTTPPoliciesPolAssoIdDelete(c *gin.Context) {

--- a/ampolicy/routers.go
+++ b/ampolicy/routers.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/pcf/logger"
 	logger_util "github.com/omec-project/util/logger"
 )

--- a/ampolicy/routers.go
+++ b/ampolicy/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/pcf/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/bdtpolicy/api_bdt_policies_collection_routers.go
+++ b/bdtpolicy/api_bdt_policies_collection_routers.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/bdtpolicy/api_bdt_policies_collection_routers.go
+++ b/bdtpolicy/api_bdt_policies_collection_routers.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // CreateBDTPolicy - Create a new Individual BDT policy

--- a/bdtpolicy/api_individual_bdt_policy_document_routers.go
+++ b/bdtpolicy/api_individual_bdt_policy_document_routers.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/bdtpolicy/api_individual_bdt_policy_document_routers.go
+++ b/bdtpolicy/api_individual_bdt_policy_document_routers.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // GetBDTPolicy - Read an Individual BDT policy

--- a/bdtpolicy/routers.go
+++ b/bdtpolicy/routers.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/pcf/logger"
 	logger_util "github.com/omec-project/util/logger"
 )

--- a/bdtpolicy/routers.go
+++ b/bdtpolicy/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/pcf/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/consumer/communication.go
+++ b/consumer/communication.go
@@ -19,7 +19,8 @@ import (
 )
 
 func AmfStatusChangeSubscribe(amfUri string, guamiList []models.Guami) (
-	problemDetails *models.ProblemDetails, err error) {
+	problemDetails *models.ProblemDetails, err error,
+) {
 	logger.Consumerlog.Debugf("PCF Subscribe to AMF status[%+v]", amfUri)
 	pcfSelf := pcf_context.PCF_Self()
 	client := util.GetNamfClient(amfUri)
@@ -29,8 +30,7 @@ func AmfStatusChangeSubscribe(amfUri string, guamiList []models.Guami) (
 		GuamiList:    guamiList,
 	}
 
-	res, httpResp, localErr :=
-		client.SubscriptionsCollectionDocumentApi.AMFStatusChangeSubscribe(context.Background(), subscriptionData)
+	res, httpResp, localErr := client.SubscriptionsCollectionDocumentApi.AMFStatusChangeSubscribe(context.Background(), subscriptionData)
 	if localErr == nil {
 		locationHeader := httpResp.Header.Get("Location")
 		logger.Consumerlog.Debugf("location header: %+v", locationHeader)

--- a/consumer/nf_discovery.go
+++ b/consumer/nf_discovery.go
@@ -20,7 +20,8 @@ import (
 
 var SendSearchNFInstances = func(
 	nrfUri string, targetNfType, requestNfType models.NfType, param Nnrf_NFDiscovery.SearchNFInstancesParamOpts) (
-	*models.SearchResult, error) {
+	*models.SearchResult, error,
+) {
 	// Set client and set url
 	configuration := Nnrf_NFDiscovery.NewConfiguration()
 	configuration.SetBasePath(nrfUri)

--- a/consumer/nf_discovery.go
+++ b/consumer/nf_discovery.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 
 	"github.com/antihax/optional"
-
 	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -54,7 +54,8 @@ func BuildNFInstance(context *pcf_context.PCFContext) (profile models.NfProfile,
 }
 
 var SendRegisterNFInstance = func(nrfUri, nfInstanceId string, profile models.NfProfile) (
-	nfProfile models.NfProfile, resouceNrfUri string, retrieveNfInstanceID string, err error) {
+	nfProfile models.NfProfile, resouceNrfUri string, retrieveNfInstanceID string, err error,
+) {
 	// Set client and set url
 	configuration := Nnrf_NFManagement.NewConfiguration()
 	configuration.SetBasePath(nrfUri)

--- a/context/context.go
+++ b/context/context.go
@@ -76,7 +76,7 @@ type PccPolicy struct {
 	PccRules      map[string]*models.PccRule
 	QosDecs       map[string]*models.QosData
 	TraffContDecs map[string]*models.TrafficControlData
-	SessionPolicy map[string]*SessionPolicy //dnn is key
+	SessionPolicy map[string]*SessionPolicy // dnn is key
 	IdGenerator   *idgenerator.IDGenerator
 }
 type PcfSubscriberPolicyData struct {

--- a/context/ue.go
+++ b/context/ue.go
@@ -127,7 +127,8 @@ func (ue *UeContext) NewUeAMPolicyData(assolId string, req models.PolicyAssociat
 
 // returns UeSmPolicyData and insert related info to Ue with smPolId
 func (ue *UeContext) NewUeSmPolicyData(
-	key string, request models.SmPolicyContextData, smData *models.SmPolicyData) *UeSmPolicyData {
+	key string, request models.SmPolicyContextData, smData *models.SmPolicyData,
+) *UeSmPolicyData {
 	if smData == nil {
 		return nil
 	}
@@ -426,7 +427,8 @@ func (ue *UeContext) SMPolicyFindByIpv6(v6 string) *UeSmPolicyData {
 
 // returns SM Policy by IPv4
 func (ue *UeContext) SMPolicyFindByIdentifiersIpv4(
-	v4 string, sNssai *models.Snssai, dnn string, ipDomain string) *UeSmPolicyData {
+	v4 string, sNssai *models.Snssai, dnn string, ipDomain string,
+) *UeSmPolicyData {
 	for _, smPolicy := range ue.SmPolicyData {
 		policyContext := smPolicy.PolicyContext
 		if policyContext.Ipv4Address == v4 {

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -13,9 +13,8 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/omec-project/pcf/logger"
+	"gopkg.in/yaml.v2"
 )
 
 var PcfConfig Config

--- a/httpcallback/amf_status_change_notify.go
+++ b/httpcallback/amf_status_change_notify.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/httpcallback/router.go
+++ b/httpcallback/router.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/pcf/logger"
 	logger_util "github.com/omec-project/util/logger"
 )

--- a/httpcallback/sm_policy_notify.go
+++ b/httpcallback/sm_policy_notify.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/internal/notifyevent/dispatcher.go
+++ b/internal/notifyevent/dispatcher.go
@@ -6,10 +6,9 @@
 package notifyevent
 
 import (
-	"github.com/tim-ywliu/event"
-
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
+	"github.com/tim-ywliu/event"
 )
 
 var notifyDispatcher *event.Dispatcher

--- a/internal/notifyevent/send_smpolicy_termination.go
+++ b/internal/notifyevent/send_smpolicy_termination.go
@@ -9,11 +9,10 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/tim-ywliu/event"
-
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/util"
+	"github.com/tim-ywliu/event"
 )
 
 const SendSMpolicyTerminationNotifyEventName event.Name = "SendSMpolicyTerminationNotify"

--- a/internal/notifyevent/send_smpolicy_termination.go
+++ b/internal/notifyevent/send_smpolicy_termination.go
@@ -30,8 +30,7 @@ func (e SendSMpolicyTerminationNotifyEvent) Handle() {
 	}
 	client := util.GetNpcfSMPolicyCallbackClient()
 	logger.NotifyEventLog.Infof("SM Policy Termination Request Notification to SMF")
-	rsp, err :=
-		client.DefaultCallbackApi.SmPolicyControlTerminationRequestNotification(context.Background(), e.uri, *e.request)
+	rsp, err := client.DefaultCallbackApi.SmPolicyControlTerminationRequestNotification(context.Background(), e.uri, *e.request)
 	if err != nil {
 		if rsp != nil {
 			logger.NotifyEventLog.Warnf("SM Policy Termination Request Notification Error[%s]", rsp.Status)

--- a/internal/notifyevent/send_smpolicy_update.go
+++ b/internal/notifyevent/send_smpolicy_update.go
@@ -30,8 +30,7 @@ func (e SendSMpolicyUpdateNotifyEvent) Handle() {
 	}
 	client := util.GetNpcfSMPolicyCallbackClient()
 	logger.NotifyEventLog.Infof("Send SM Policy Update Notification to SMF")
-	_, httpResponse, err :=
-		client.DefaultCallbackApi.SmPolicyUpdateNotification(context.Background(), e.uri, *e.request)
+	_, httpResponse, err := client.DefaultCallbackApi.SmPolicyUpdateNotification(context.Background(), e.uri, *e.request)
 	if err != nil {
 		if httpResponse != nil {
 			logger.NotifyEventLog.Warnf("SM Policy Update Notification Error[%s]", httpResponse.Status)

--- a/internal/notifyevent/send_smpolicy_update.go
+++ b/internal/notifyevent/send_smpolicy_update.go
@@ -9,11 +9,10 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/tim-ywliu/event"
-
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/util"
+	"github.com/tim-ywliu/event"
 )
 
 const SendSMpolicyUpdateNotifyEventName event.Name = "SendSMpolicyUpdateNotify"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -11,10 +11,9 @@ import (
 	"time"
 
 	formatter "github.com/antonfisher/nested-logrus-formatter"
-	"github.com/sirupsen/logrus"
-
 	"github.com/omec-project/util/logger"
 	"github.com/omec-project/util/logger_conf"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/oam/api_get_am_policy.go
+++ b/oam/api_get_am_policy.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/oam/api_get_am_policy.go
+++ b/oam/api_get_am_policy.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 func setCorsHeader(c *gin.Context) {

--- a/oam/routers.go
+++ b/oam/routers.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/pcf/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/oam/routers.go
+++ b/oam/routers.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/pcf/logger"
 	logger_util "github.com/omec-project/util/logger"
 )

--- a/pcf.go
+++ b/pcf.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
-
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/service"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
 )
 
 var PCF = &service.PCF{}

--- a/pcf_test.go
+++ b/pcf_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var PCFTest = &service.PCF{}
-var bitRateValues = make(map[int64]string)
+var (
+	PCFTest       = &service.PCF{}
+	bitRateValues = make(map[int64]string)
+)
 
 func init() {
 	bitRateValues = map[int64]string{

--- a/policyauthorization/api_application_sessions_collection.go
+++ b/policyauthorization/api_application_sessions_collection.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/policyauthorization/api_application_sessions_collection.go
+++ b/policyauthorization/api_application_sessions_collection.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
 	"github.com/omec-project/pcf/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // HTTPPostAppSessions - Creates a new Individual Application Session Context resource

--- a/policyauthorization/api_events_subscription_document.go
+++ b/policyauthorization/api_events_subscription_document.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/policyauthorization/api_events_subscription_document.go
+++ b/policyauthorization/api_events_subscription_document.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
 	"github.com/omec-project/pcf/util"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // HTTPDeleteEventsSubsc - deletes the Events Subscription subresource

--- a/policyauthorization/api_individual_application_session_context_document.go
+++ b/policyauthorization/api_individual_application_session_context_document.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/policyauthorization/api_individual_application_session_context_document.go
+++ b/policyauthorization/api_individual_application_session_context_document.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // HTTPDeleteAppSession - Deletes an existing Individual Application Session Context

--- a/policyauthorization/routers.go
+++ b/policyauthorization/routers.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/pcf/logger"
 	logger_util "github.com/omec-project/util/logger"
 )

--- a/policyauthorization/routers.go
+++ b/policyauthorization/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/pcf/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/producer/ampolicy.go
+++ b/producer/ampolicy.go
@@ -111,7 +111,8 @@ func HandleUpdatePostPoliciesPolAssoId(request *httpwrapper.Request) *httpwrappe
 }
 
 func UpdatePostPoliciesPolAssoIdProcedure(polAssoId string,
-	policyAssociationUpdateRequest models.PolicyAssociationUpdateRequest) (*models.PolicyUpdate, *models.ProblemDetails) {
+	policyAssociationUpdateRequest models.PolicyAssociationUpdateRequest,
+) (*models.PolicyUpdate, *models.ProblemDetails) {
 	ue := pcf_context.PCF_Self().PCFUeFindByPolicyId(polAssoId)
 	if ue == nil || ue.AMPolicyData[polAssoId] == nil {
 		problemDetails := util.GetProblemDetail("polAssoId not found  in PCF", util.CONTEXT_NOT_FOUND)
@@ -206,7 +207,8 @@ func HandlePostPolicies(request *httpwrapper.Request) *httpwrapper.Response {
 }
 
 func PostPoliciesProcedure(polAssoId string,
-	policyAssociationRequest models.PolicyAssociationRequest) (*models.PolicyAssociation, string, *models.ProblemDetails) {
+	policyAssociationRequest models.PolicyAssociationRequest,
+) (*models.PolicyAssociation, string, *models.ProblemDetails) {
 	var response models.PolicyAssociation
 	pcfSelf := pcf_context.PCF_Self()
 	var ue *pcf_context.UeContext
@@ -366,7 +368,8 @@ func SendAMPolicyUpdateNotification(ue *pcf_context.UeContext, PolId string, req
 
 // Send AM Policy Update to AMF if policy has been terminated
 func SendAMPolicyTerminationRequestNotification(ue *pcf_context.UeContext,
-	PolId string, request models.TerminationNotification) {
+	PolId string, request models.TerminationNotification,
+) {
 	if ue == nil {
 		logger.AMpolicylog.Warnln("Policy Assocition Termination Request Notification Error[Ue is nil]")
 		return

--- a/producer/ampolicy.go
+++ b/producer/ampolicy.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 
 	"github.com/mohae/deepcopy"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/consumer"

--- a/producer/bdtpolicy.go
+++ b/producer/bdtpolicy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/antihax/optional"
 	"github.com/google/uuid"
 	"github.com/mohae/deepcopy"
-
 	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
 	"github.com/omec-project/openapi/Nudr_DataRepository"
 	"github.com/omec-project/openapi/models"

--- a/producer/bdtpolicy.go
+++ b/producer/bdtpolicy.go
@@ -48,7 +48,8 @@ func HandleGetBDTPolicyContextRequest(request *httpwrapper.Request) *httpwrapper
 }
 
 func getBDTPolicyContextProcedure(bdtPolicyID string) (
-	response *models.BdtPolicy, problemDetails *models.ProblemDetails) {
+	response *models.BdtPolicy, problemDetails *models.ProblemDetails,
+) {
 	logger.Bdtpolicylog.Traceln("Handle BDT Policy GET")
 	// check bdtPolicyID from pcfUeContext
 	if value, ok := pcf_context.PCF_Self().BdtPolicyPool.Load(bdtPolicyID); ok {
@@ -89,7 +90,8 @@ func HandleUpdateBDTPolicyContextProcedure(request *httpwrapper.Request) *httpwr
 }
 
 func updateBDTPolicyContextProcedure(request models.BdtPolicyDataPatch, bdtPolicyID string) (
-	response *models.BdtPolicy, problemDetails *models.ProblemDetails) {
+	response *models.BdtPolicy, problemDetails *models.ProblemDetails,
+) {
 	logger.Bdtpolicylog.Infoln("Handle BDTPolicyUpdate")
 	// check bdtPolicyID from pcfUeContext
 	pcfSelf := pcf_context.PCF_Self()
@@ -166,7 +168,8 @@ func HandleCreateBDTPolicyContextRequest(request *httpwrapper.Request) *httpwrap
 }
 
 func createBDTPolicyContextProcedure(request *models.BdtReqData) (
-	header http.Header, response *models.BdtPolicy, problemDetails *models.ProblemDetails) {
+	header http.Header, response *models.BdtPolicy, problemDetails *models.ProblemDetails,
+) {
 	response = &models.BdtPolicy{}
 	logger.Bdtpolicylog.Traceln("Handle BDT Policy Create")
 

--- a/producer/policyauthorization.go
+++ b/producer/policyauthorization.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/cydev/zero"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	pcf_context "github.com/omec-project/pcf/context"

--- a/producer/policyauthorization.go
+++ b/producer/policyauthorization.go
@@ -62,7 +62,8 @@ func transferMedCompRmToMedComp(medCompRm *models.MediaComponentRm) *models.Medi
 
 // Handle Create/ Modify  Media SubComponent
 func handleMediaSubComponent(smPolicy *pcf_context.UeSmPolicyData, medComp *models.MediaComponent,
-	medSubComp *models.MediaSubComponent, var5qi int32) (*models.PccRule, *models.ProblemDetails) {
+	medSubComp *models.MediaSubComponent, var5qi int32,
+) (*models.PccRule, *models.ProblemDetails) {
 	var flowInfos []models.FlowInformation
 	if tempFlowInfos, err := getFlowInfos(medSubComp); err != nil {
 		problemDetail := util.GetProblemDetail(err.Error(), util.REQUESTED_SERVICE_NOT_AUTHORIZED)
@@ -151,7 +152,8 @@ func HandlePostAppSessionsContext(request *httpwrapper.Request) *httpwrapper.Res
 }
 
 func postAppSessCtxProcedure(appSessCtx *models.AppSessionContext) (*models.AppSessionContext,
-	string, *models.ProblemDetails) {
+	string, *models.ProblemDetails,
+) {
 	ascReqData := appSessCtx.AscReqData
 	pcfSelf := pcf_context.PCF_Self()
 
@@ -445,7 +447,8 @@ func HandleDeleteAppSessionContext(request *httpwrapper.Request) *httpwrapper.Re
 }
 
 func DeleteAppSessionContextProcedure(appSessID string,
-	eventsSubscReqData *models.EventsSubscReqData) *models.ProblemDetails {
+	eventsSubscReqData *models.EventsSubscReqData,
+) *models.ProblemDetails {
 	pcfSelf := pcf_context.PCF_Self()
 	var appSession *pcf_context.AppSessionData
 	if val, ok := pcfSelf.AppSessionPool.Load(appSessID); ok {
@@ -541,7 +544,8 @@ func HandleModAppSessionContext(request *httpwrapper.Request) *httpwrapper.Respo
 }
 
 func ModAppSessionContextProcedure(appSessID string,
-	ascUpdateData models.AppSessionContextUpdateData) (*models.ProblemDetails, *models.AppSessionContext) {
+	ascUpdateData models.AppSessionContextUpdateData,
+) (*models.ProblemDetails, *models.AppSessionContext) {
 	pcfSelf := pcf_context.PCF_Self()
 	var appSession *pcf_context.AppSessionData
 	if val, ok := pcfSelf.AppSessionPool.Load(appSessID); ok {
@@ -715,8 +719,7 @@ func ModAppSessionContextProcedure(appSessID string,
 				continue
 			}
 			if !util.CheckPolicyControlReqTrig(smPolicy.PolicyDecision.PolicyCtrlReqTriggers, trig) {
-				smPolicy.PolicyDecision.PolicyCtrlReqTriggers =
-					append(smPolicy.PolicyDecision.PolicyCtrlReqTriggers, trig)
+				smPolicy.PolicyDecision.PolicyCtrlReqTriggers = append(smPolicy.PolicyDecision.PolicyCtrlReqTriggers, trig)
 				updateSMpolicy = true
 			}
 		}
@@ -921,7 +924,8 @@ func SendAppSessionEventNotification(appSession *pcf_context.AppSessionData, req
 }
 
 func UpdateEventsSubscContextProcedure(appSessID string, eventsSubscReqData models.EventsSubscReqData) (
-	*models.UpdateEventsSubscResponse, string, int, *models.ProblemDetails) {
+	*models.UpdateEventsSubscResponse, string, int, *models.ProblemDetails,
+) {
 	pcfSelf := pcf_context.PCF_Self()
 
 	var appSession *pcf_context.AppSessionData
@@ -977,8 +981,7 @@ func UpdateEventsSubscContextProcedure(appSessID string, eventsSubscReqData mode
 			continue
 		}
 		if !util.CheckPolicyControlReqTrig(smPolicy.PolicyDecision.PolicyCtrlReqTriggers, trig) {
-			smPolicy.PolicyDecision.PolicyCtrlReqTriggers =
-				append(smPolicy.PolicyDecision.PolicyCtrlReqTriggers, trig)
+			smPolicy.PolicyDecision.PolicyCtrlReqTriggers = append(smPolicy.PolicyDecision.PolicyCtrlReqTriggers, trig)
 			updataSmPolicy = true
 		}
 	}
@@ -1096,7 +1099,8 @@ func SendAppSessionTermination(appSession *pcf_context.AppSessionData, request m
 
 // Handle Create/ Modify Background Data Transfer Policy Indication
 func handleBDTPolicyInd(pcfSelf *pcf_context.PCFContext,
-	appSessCtx *models.AppSessionContext) (err error) {
+	appSessCtx *models.AppSessionContext,
+) (err error) {
 	req := appSessCtx.AscReqData
 
 	var requestSuppFeat openapi.SupportedFeature
@@ -1144,7 +1148,8 @@ func handleBDTPolicyInd(pcfSelf *pcf_context.PCFContext,
 // provisioning of sponsored connectivity information
 func handleSponsoredConnectivityInformation(smPolicy *pcf_context.UeSmPolicyData, relatedPccRuleIds map[string]string,
 	aspID, sponID string, sponStatus models.SponsoringStatus, umData *models.UsageMonitoringData,
-	updateSMpolicy *bool) error {
+	updateSMpolicy *bool,
+) error {
 	if sponStatus == models.SponsoringStatus_DISABLED {
 		logger.PolicyAuthorizationlog.Debugf("Sponsored Connectivity is disabled by AF")
 		umID := util.GetUmId(aspID, sponID)
@@ -1329,7 +1334,8 @@ func flowDescFromN5toN7(n5Flow string) (n7Flow string, direction models.FlowDire
 }
 
 func updateQosInMedComp(qosData models.QosData, comp *models.MediaComponent) (models.QosData,
-	bool, bool) {
+	bool, bool,
+) {
 	var dlExist bool
 	var ulExist bool
 	updatedQosData := qosData
@@ -1459,7 +1465,8 @@ func updateQosInMedComp(qosData models.QosData, comp *models.MediaComponent) (mo
 }
 
 func updateQosInMedSubComp(qosData *models.QosData, comp *models.MediaComponent,
-	subsComp *models.MediaSubComponent) (updatedQosData models.QosData, ulExist, dlExist bool) {
+	subsComp *models.MediaSubComponent,
+) (updatedQosData models.QosData, ulExist, dlExist bool) {
 	updatedQosData = *qosData
 	if comp.FStatus == models.FlowStatus_REMOVED {
 		updatedQosData.MaxbrDl = ""
@@ -1651,7 +1658,8 @@ func threshRmToThresh(threshrm *models.UsageThresholdRm) *models.UsageThreshold 
 }
 
 func extractUmData(umID string, eventSubs map[models.AfEvent]models.AfNotifMethod,
-	threshold *models.UsageThreshold) (umData *models.UsageMonitoringData, err error) {
+	threshold *models.UsageThreshold,
+) (umData *models.UsageMonitoringData, err error) {
 	if _, umExist := eventSubs[models.AfEvent_USAGE_REPORT]; umExist {
 		if threshold == nil {
 			return nil, fmt.Errorf("UsageThreshold is nil in USAGE REPORT Subscription")
@@ -1664,7 +1672,8 @@ func extractUmData(umID string, eventSubs map[models.AfEvent]models.AfNotifMetho
 }
 
 func modifyRemainBitRate(smPolicy *pcf_context.UeSmPolicyData, qosData *models.QosData,
-	ulExist, dlExist bool) *models.ProblemDetails {
+	ulExist, dlExist bool,
+) *models.ProblemDetails {
 	// if request GBR == 0, qos GBR = MBR
 	// if request GBR > remain GBR, qos GBR = remain GBR
 	if ulExist {
@@ -1707,7 +1716,8 @@ func modifyRemainBitRate(smPolicy *pcf_context.UeSmPolicyData, qosData *models.Q
 }
 
 func provisioningOfTrafficRoutingInfo(smPolicy *pcf_context.UeSmPolicyData, appID string,
-	routeReq *models.AfRoutingRequirement, fStatus models.FlowStatus) *models.PccRule {
+	routeReq *models.AfRoutingRequirement, fStatus models.FlowStatus,
+) *models.PccRule {
 	var tcData *models.TrafficControlData
 
 	// TODO : handle temporal or spatial validity

--- a/producer/smpolicy.go
+++ b/producer/smpolicy.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/antihax/optional"
 	"github.com/mohae/deepcopy"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/Nudr_DataRepository"
 	"github.com/omec-project/openapi/models"

--- a/producer/smpolicy.go
+++ b/producer/smpolicy.go
@@ -46,7 +46,8 @@ func HandleCreateSmPolicyRequest(request *httpwrapper.Request) *httpwrapper.Resp
 }
 
 func createSMPolicyProcedure(request models.SmPolicyContextData) (
-	header http.Header, response *models.SmPolicyDecision, problemDetails *models.ProblemDetails) {
+	header http.Header, response *models.SmPolicyDecision, problemDetails *models.ProblemDetails,
+) {
 	var err error
 	logger.SMpolicylog.Tracef("Handle Create SM Policy Request")
 
@@ -125,7 +126,7 @@ func createSMPolicyProcedure(request models.SmPolicyContextData) (
 		TraffContDecs: make(map[string]*models.TrafficControlData),
 	}
 
-	//Check if local config has pre-configured pccrules, sessionrules for the slice(via ROC)
+	// Check if local config has pre-configured pccrules, sessionrules for the slice(via ROC)
 	sstStr := strconv.Itoa(int(request.SliceInfo.Sst))
 	sliceid := sstStr + request.SliceInfo.Sd
 	self := pcf_context.PCF_Self()
@@ -240,8 +241,7 @@ func createSMPolicyProcedure(request models.SmPolicyContextData) (
 	if err != nil {
 		logger.SMpolicylog.Errorf("openapi NewSupportedFeature error: %+v", err)
 	}
-	decision.SuppFeat =
-		pcfSelf.PcfSuppFeats[models.ServiceName_NPCF_SMPOLICYCONTROL].NegotiateWith(requestSuppFeat).String()
+	decision.SuppFeat = pcfSelf.PcfSuppFeats[models.ServiceName_NPCF_SMPOLICYCONTROL].NegotiateWith(requestSuppFeat).String()
 	decision.QosFlowUsage = request.QosFlowUsage
 	// TODO: Trigger about UMC, ADC, NetLoc,...
 	decision.PolicyCtrlReqTriggers = util.PolicyControlReqTrigToArray(0x40780f)
@@ -335,7 +335,8 @@ func HandleGetSmPolicyContextRequest(request *httpwrapper.Request) *httpwrapper.
 }
 
 func getSmPolicyContextProcedure(smPolicyID string) (
-	response *models.SmPolicyControl, problemDetails *models.ProblemDetails) {
+	response *models.SmPolicyControl, problemDetails *models.ProblemDetails,
+) {
 	logger.SMpolicylog.Traceln("Handle GET SM Policy Request")
 
 	ue := pcf_context.PCF_Self().PCFUeFindByPolicyId(smPolicyID)
@@ -380,7 +381,8 @@ func HandleUpdateSmPolicyContextRequest(request *httpwrapper.Request) *httpwrapp
 }
 
 func updateSmPolicyContextProcedure(request models.SmPolicyUpdateContextData, smPolicyID string) (
-	response *models.SmPolicyDecision, problemDetails *models.ProblemDetails) {
+	response *models.SmPolicyDecision, problemDetails *models.ProblemDetails,
+) {
 	logger.SMpolicylog.Traceln("Handle updateSmPolicyContext")
 
 	ue := pcf_context.PCF_Self().PCFUeFindByPolicyId(smPolicyID)
@@ -753,7 +755,8 @@ func updateSmPolicyContextProcedure(request models.SmPolicyUpdateContextData, sm
 
 func sendSmPolicyRelatedAppSessionNotification(smPolicy *pcf_context.UeSmPolicyData,
 	notification models.EventsNotification, usageReports []models.AccuUsageReport,
-	successRules, failRules []models.RuleReport) {
+	successRules, failRules []models.RuleReport,
+) {
 	for appSessionId := range smPolicy.AppSessions {
 		if val, exist := pcf_context.PCF_Self().AppSessionPool.Load(appSessionId); exist {
 			appSession := val.(*pcf_context.AppSessionData)
@@ -818,8 +821,7 @@ func sendSmPolicyRelatedAppSessionNotification(smPolicy *pcf_context.UeSmPolicyD
 							failItem.Flows = append(failItem.Flows, flow)
 						}
 						if failItem.Flows != nil {
-							sessionNotif.FailedResourcAllocReports =
-								append(sessionNotif.FailedResourcAllocReports, failItem)
+							sessionNotif.FailedResourcAllocReports = append(sessionNotif.FailedResourcAllocReports, failItem)
 						} else {
 							continue
 						}
@@ -890,8 +892,7 @@ func sendSmPolicyRelatedAppSessionNotification(smPolicy *pcf_context.UeSmPolicyD
 					case models.AfEvent_USAGE_REPORT:
 						for _, report := range usageReports {
 							for _, pccRuleId := range appSession.RelatedPccRuleIds {
-								if pccRule, exist :=
-									appSession.SmPolicyData.PolicyDecision.PccRules[pccRuleId]; exist {
+								if pccRule, exist := appSession.SmPolicyData.PolicyDecision.PccRules[pccRuleId]; exist {
 									if pccRule.RefUmData != nil && pccRule.RefUmData[0] == report.RefUmIds {
 										sessionNotif.UsgRep = &models.AccumulatedUsage{
 											Duration:       report.TimeUsage,

--- a/service/init.go
+++ b/service/init.go
@@ -522,7 +522,7 @@ func getPccRules(slice *protos.NetworkSlice, sessionRule *models.SessionRule) (p
 		}
 		var rule models.PccRule
 		var qos models.QosData
-		rule.PccRuleId = strconv.FormatInt(int64(id), 10)
+		rule.PccRuleId = strconv.FormatInt(id, 10)
 		rule.Precedence = pccrule.Priority
 		if pccrule.Qos != nil {
 			qos.QosId = strconv.FormatInt(id, 10)

--- a/service/init.go
+++ b/service/init.go
@@ -21,9 +21,6 @@ import (
 
 	"github.com/antihax/optional"
 	"github.com/gin-contrib/cors"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
-
 	"github.com/omec-project/config5g/proto/client"
 	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
 	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
@@ -47,6 +44,8 @@ import (
 	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/util/path_util"
 	pathUtilLogger "github.com/omec-project/util/path_util/logger"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
 )
 
 type PCF struct{}

--- a/smpolicy/api_default.go
+++ b/smpolicy/api_default.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"

--- a/smpolicy/api_default.go
+++ b/smpolicy/api_default.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/omec-project/util/httpwrapper"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pcf/logger"
 	"github.com/omec-project/pcf/producer"
+	"github.com/omec-project/util/httpwrapper"
 )
 
 // SmPoliciesPost -

--- a/smpolicy/routers.go
+++ b/smpolicy/routers.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/pcf/logger"
 	logger_util "github.com/omec-project/util/logger"
 )

--- a/smpolicy/routers.go
+++ b/smpolicy/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/pcf/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 // Route is the information for every URI.

--- a/uepolicy/routers.go
+++ b/uepolicy/routers.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/omec-project/pcf/logger"
 	logger_util "github.com/omec-project/util/logger"
 )

--- a/uepolicy/routers.go
+++ b/uepolicy/routers.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	logger_util "github.com/omec-project/util/logger"
 	"github.com/omec-project/pcf/logger"
+	logger_util "github.com/omec-project/util/logger"
 )
 
 type Route struct {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -66,8 +66,7 @@ func InitpcfContext(context *context.PCFContext) {
 	context.DefaultBdtRefId = configuration.DefaultBdtRefId
 	for _, service := range context.NfService {
 		var err error
-		context.PcfServiceUris[service.ServiceName] =
-			service.ApiPrefix + "/" + string(service.ServiceName) + "/" + (*service.Versions)[0].ApiVersionInUri
+		context.PcfServiceUris[service.ServiceName] = service.ApiPrefix + "/" + string(service.ServiceName) + "/" + (*service.Versions)[0].ApiVersionInUri
 		context.PcfSuppFeats[service.ServiceName], err = openapi.NewSupportedFeature(service.SupportedFeatures)
 		if err != nil {
 			logger.UtilLog.Errorf("openapi NewSupportedFeature error: %+v", err)

--- a/util/pcc_rule.go
+++ b/util/pcc_rule.go
@@ -182,7 +182,8 @@ func GetPccRuleByFlowInfos(pccRules map[string]*models.PccRule, flowInfos []mode
 
 func SetPccRuleRelatedData(decicion *models.SmPolicyDecision, pccRule *models.PccRule,
 	tcData *models.TrafficControlData, qosData *models.QosData, chgData *models.ChargingData,
-	umData *models.UsageMonitoringData) {
+	umData *models.UsageMonitoringData,
+) {
 	if tcData != nil {
 		if decicion.TraffContDecs == nil {
 			decicion.TraffContDecs = make(map[string]*models.TrafficControlData)

--- a/util/pcf_util.go
+++ b/util/pcf_util.go
@@ -238,7 +238,8 @@ func CheckSuppFeat(suppFeat string, number int) bool {
 }
 
 func CheckPolicyControlReqTrig(
-	triggers []models.PolicyControlRequestTrigger, reqTrigger models.PolicyControlRequestTrigger) bool {
+	triggers []models.PolicyControlRequestTrigger, reqTrigger models.PolicyControlRequestTrigger,
+) bool {
 	for _, trigger := range triggers {
 		if trigger == reqTrigger {
 			return true

--- a/util/search_nf_service.go
+++ b/util/search_nf_service.go
@@ -13,7 +13,8 @@ import (
 
 // SearchNFServiceUri returns NF Uri derived from NfProfile with corresponding service
 func SearchNFServiceUri(nfProfile models.NfProfile, serviceName models.ServiceName,
-	nfServiceStatus models.NfServiceStatus) (nfUri string) {
+	nfServiceStatus models.NfServiceStatus,
+) (nfUri string) {
 	if nfProfile.NfServices != nil {
 		for _, service := range *nfProfile.NfServices {
 			if service.ServiceName == serviceName && service.NfServiceStatus == nfServiceStatus {


### PR DESCRIPTION
This PR includesthe following:
- Applies `gofmt` to all files
- Applies `gci` to all files
- Applies `gofumpt` to all files
- Enables `unconvert`, `ineffassign` and `goconst` linters
- Adds GO report card
