### PR TITLE
feat: parametrize paths for TLS certificate and private key

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -42,6 +42,8 @@ type PCFContext struct {
 	UriScheme       models.UriScheme
 	BindingIPv4     string
 	RegisterIPv4    string
+	Key             string
+	PEM             string
 	TimeFormat      string
 	DefaultBdtRefId string
 	NfService       map[models.ServiceName]models.NfService

--- a/factory/config.go
+++ b/factory/config.go
@@ -59,10 +59,16 @@ type Service struct {
 
 type Sbi struct {
 	Scheme       string `yaml:"scheme"`
+	TLS          *TLS   `yaml:"tls"`
 	RegisterIPv4 string `yaml:"registerIPv4,omitempty"` // IP that is registered at NRF.
 	// IPv6Addr  string `yaml:"ipv6Addr,omitempty"`
 	BindingIPv4 string `yaml:"bindingIPv4,omitempty"` // IP used to run the server in the node.
 	Port        int    `yaml:"port,omitempty"`
+}
+
+type TLS struct {
+	PEM string `yaml:"pem,omitempty"`
+	Key string `yaml:"key,omitempty"`
 }
 
 type PlmnSupportItem struct {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -32,6 +32,8 @@ func InitpcfContext(context *context.PCFContext) {
 	context.UriScheme = ""
 	context.RegisterIPv4 = factory.PCF_DEFAULT_IPV4 // default localhost
 	context.SBIPort = factory.PCF_DEFAULT_PORT_INT  // default port
+	context.Key = PCF_KEY_PATH                      // default key path
+	context.PEM = PCF_PEM_PATH                      // default PEM path
 	if sbi != nil {
 		if sbi.Scheme != "" {
 			context.UriScheme = models.UriScheme(sbi.Scheme)
@@ -46,6 +48,14 @@ func InitpcfContext(context *context.PCFContext) {
 			context.UriScheme = models.UriScheme_HTTPS
 		} else {
 			context.UriScheme = models.UriScheme_HTTP
+		}
+		if tls := sbi.TLS; tls != nil {
+			if tls.Key != "" {
+				context.Key = tls.Key
+			}
+			if tls.PEM != "" {
+				context.PEM = tls.PEM
+			}
 		}
 
 		context.BindingIPv4 = os.Getenv(sbi.BindingIPv4)


### PR DESCRIPTION
This PR adds a `tls` container, composed of `pem` and `key` keys, inside `sbi` container to specify the paths of TLS certificate and private key to use for the HTTPS server.
If the `tls` container is not specified, or `key` or `pem` are not specified, the values are defaulted to maintain backward compatibility.