### PR TITLE
chore: enable static check and govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,16 +21,15 @@ linters:
     - goconst
     - godox
     - gomodguard
+    - govet
     - misspell
     - nakedret
     - noctx
     - predeclared
+    - staticcheck
     - unconvert
     - unparam
     - whitespace
-  disable:
-    - govet
-    - staticcheck
   settings:
     errcheck:
       check-type-assertions: false
@@ -64,6 +63,8 @@ linters:
         - XXX
     govet:
       enable-all: true
+      disable:
+        - fieldalignment
       settings:
         printf:
           funcs:

--- a/producer/policyauthorization.go
+++ b/producer/policyauthorization.go
@@ -957,10 +957,7 @@ func UpdateEventsSubscContextProcedure(appSessID string, eventsSubscReqData mode
 	eventSubs := make(map[models.AfEvent]models.AfNotifMethod)
 
 	updataSmPolicy := false
-	created := false
-	if appSession.Events == nil {
-		created = true
-	}
+	created := appSession.Events == nil
 
 	for _, subs := range eventsSubscReqData.Events {
 		if subs.NotifMethod == "" {
@@ -1339,10 +1336,10 @@ func flowDescFromN5toN7(n5Flow string) (n7Flow string, direction models.FlowDire
 		n7Flow = n5Flow
 		direction = models.FlowDirection_DOWNLINK
 	} else if strings.HasPrefix(n5Flow, "permit in") {
-		n7Flow = strings.Replace(n5Flow, "permit in", "permit out", -1)
+		n7Flow = strings.ReplaceAll(n5Flow, "permit in", "permit out")
 		direction = models.FlowDirection_UPLINK
 	} else if strings.HasPrefix(n5Flow, "permit inout") {
-		n7Flow = strings.Replace(n5Flow, "permit inout", "permit out", -1)
+		n7Flow = strings.ReplaceAll(n5Flow, "permit inout", "permit out")
 		direction = models.FlowDirection_BIDIRECTIONAL
 	} else {
 		err = fmt.Errorf("invaild flow description[%s]", n5Flow)

--- a/service/init.go
+++ b/service/init.go
@@ -288,10 +288,14 @@ func (pcf *PCF) Start() {
 	}
 
 	serverScheme := factory.PcfConfig.Configuration.Sbi.Scheme
-	if serverScheme == "http" {
+	switch serverScheme {
+	case "http":
 		err = server.ListenAndServe()
-	} else if serverScheme == "https" {
+	case "https":
 		err = server.ListenAndServeTLS(self.PEM, self.Key)
+	default:
+		logger.InitLog.Fatalf("HTTP server setup failed: invalid server scheme %+v", serverScheme)
+		return
 	}
 
 	if err != nil {
@@ -581,14 +585,16 @@ func getPccRules(slice *protos.NetworkSlice, sessionRule *models.SessionRule) (p
 			}
 			if pccrule.Qos.Arp != nil {
 				qos.Arp = &models.Arp{PriorityLevel: pccrule.Qos.Arp.PL}
-				if pccrule.Qos.Arp.PC == protos.PccArpPc_NOT_PREEMPT {
+				switch pccrule.Qos.Arp.PC {
+				case protos.PccArpPc_NOT_PREEMPT:
 					qos.Arp.PreemptCap = models.PreemptionCapability_NOT_PREEMPT
-				} else if pccrule.Qos.Arp.PC == protos.PccArpPc_MAY_PREEMPT {
+				case protos.PccArpPc_MAY_PREEMPT:
 					qos.Arp.PreemptCap = models.PreemptionCapability_MAY_PREEMPT
 				}
-				if pccrule.Qos.Arp.PV == protos.PccArpPv_NOT_PREEMPTABLE {
+				switch pccrule.Qos.Arp.PV {
+				case protos.PccArpPv_NOT_PREEMPTABLE:
 					qos.Arp.PreemptVuln = models.PreemptionVulnerability_NOT_PREEMPTABLE
-				} else if pccrule.Qos.Arp.PV == protos.PccArpPv_PREEMPTABLE {
+				case protos.PccArpPv_PREEMPTABLE:
 					qos.Arp.PreemptVuln = models.PreemptionVulnerability_PREEMPTABLE
 				}
 			}
@@ -613,13 +619,14 @@ func getPccRules(slice *protos.NetworkSlice, sessionRule *models.SessionRule) (p
 			}
 			flow.PackFiltId = strconv.FormatInt(id, 10)
 
-			if pflow.FlowDir == protos.PccFlowDirection_DOWNLINK {
+			switch pflow.FlowDir {
+			case protos.PccFlowDirection_DOWNLINK:
 				flow.FlowDirection = models.FlowDirectionRm_DOWNLINK
-			} else if pflow.FlowDir == protos.PccFlowDirection_UPLINK {
+			case protos.PccFlowDirection_UPLINK:
 				flow.FlowDirection = models.FlowDirectionRm_UPLINK
-			} else if pflow.FlowDir == protos.PccFlowDirection_BIDIRECTIONAL {
+			case protos.PccFlowDirection_BIDIRECTIONAL:
 				flow.FlowDirection = models.FlowDirectionRm_BIDIRECTIONAL
-			} else if pflow.FlowDir == protos.PccFlowDirection_UNSPECIFIED {
+			case protos.PccFlowDirection_UNSPECIFIED:
 				flow.FlowDirection = models.FlowDirectionRm_UNSPECIFIED
 			}
 			if strings.HasSuffix(flow.FlowDescription, "any to assigned") ||
@@ -630,9 +637,10 @@ func getPccRules(slice *protos.NetworkSlice, sessionRule *models.SessionRule) (p
 			var tcData models.TrafficControlData
 			tcData.TcId = "TcId-" + strconv.FormatInt(id, 10)
 
-			if pflow.FlowStatus == protos.PccFlowStatus_ENABLED {
+			switch pflow.FlowStatus {
+			case protos.PccFlowStatus_ENABLED:
 				tcData.FlowStatus = models.FlowStatus_ENABLED
-			} else if pflow.FlowStatus == protos.PccFlowStatus_DISABLED {
+			case protos.PccFlowStatus_DISABLED:
 				tcData.FlowStatus = models.FlowStatus_DISABLED
 			}
 


### PR DESCRIPTION
this PR enables `staticcheck` and `govet` in the CI

- fix a variable declaration
- use ReplaceAll instead of Replace
- replace if with switch

govet's `fieldaligment` remains disabled