### PR TITLE
Address issue dereferencing nil pointer

### DIFF
--- a/consumer/communication.go
+++ b/consumer/communication.go
@@ -54,8 +54,10 @@ func AmfStatusChangeSubscribe(amfUri string, guamiList []models.Guami) (
 	}
 
 	defer func() {
-		if err = httpResp.Body.Close(); err != nil {
-			logger.Consumerlog.Errorf("error closing response body: %v", err)
+		if httpResp != nil {
+			if err = httpResp.Body.Close(); err != nil {
+				logger.Consumerlog.Errorf("error closing response body: %v", err)
+			}
 		}
 	}()
 

--- a/consumer/communication.go
+++ b/consumer/communication.go
@@ -54,6 +54,8 @@ func AmfStatusChangeSubscribe(amfUri string, guamiList []models.Guami) (
 	}
 
 	defer func() {
+		// httpResp can be nil in some error scenarios above; this check prevents a
+		// panic when accessing httpResp.Body
 		if httpResp != nil {
 			if err = httpResp.Body.Close(); err != nil {
 				logger.Consumerlog.Errorf("error closing response body: %v", err)


### PR DESCRIPTION
`pcf` logs a panic error due to `invalid memory address or nil pointer dereference`. This PR should take care of that
```
2025-08-19T03:53:11.119Z	ERROR	logger/logger.go:128	panic: runtime error: invalid memory address or nil pointer dereference
goroutine 100 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/omec-project/util/logger.NewGinWithZap.ginRecover.func2.1()
	/go/src/pcf/vendor/github.com/omec-project/util/logger/logger.go:111 +0x117
panic({0xf6ef40?, 0x198c750?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
github.com/omec-project/pcf/consumer.AmfStatusChangeSubscribe.func1()
	/go/src/pcf/consumer/communication.go:57 +0x1f
github.com/omec-project/pcf/consumer.AmfStatusChangeSubscribe({0xc0000e6360, 0x18}, {0xc000448b88, 0x1, 0x1})
	/go/src/pcf/consumer/communication.go:62 +0x727
github.com/omec-project/pcf/producer.PostPoliciesProcedure({_, _}, {{0xc0004ca480, 0x34}, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, ...})
	/go/src/pcf/producer/ampolicy.go:306 +0x1229
github.com/omec-project/pcf/producer.HandlePostPolicies(0xc000330f00)
	/go/src/pcf/producer/ampolicy.go:193 +0x147
github.com/omec-project/pcf/ampolicy.HTTPPoliciesPost(0xc0004ee300)
	/go/src/pcf/ampolicy/api_default.go:159 +0x5ee
github.com/gin-gonic/gin.(*Context).Next(0xc0004ee300)
	/go/src/pcf/vendor/github.com/gin-gonic/gin/context.go:185 +0x2b
github.com/omec-project/util/logger.NewGinWithZap.ginRecover.func2(0x7f68e0803f08?)
	/go/src/pcf/vendor/github.com/omec-project/util/logger/logger.go:141 +0x48
github.com/gin-gonic/gin.(*Context).Next(0xc0004ee300)
	/go/src/pcf/vendor/github.com/gin-gonic/gin/context.go:185 +0x2b
github.com/omec-project/util/logger.NewGinWithZap.ginToZap.func1(0xc0004ee300)
	/go/src/pcf/vendor/github.com/omec-project/util/logger/logger.go:80 +0x5f
github.com/gin-gonic/gin.(*Context).Next(...)
	/go/src/pcf/vendor/github.com/gin-gonic/gin/context.go:185
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest(0xc0003a2d00, 0xc0004ee300)
	/go/src/pcf/vendor/github.com/gin-gonic/gin/gin.go:644 +0x872
github.com/gin-gonic/gin.(*Engine).ServeHTTP(0xc0003a2d00, {0x1278678, 0xc00048e128}, 0xc0002617c0)
	/go/src/pcf/vendor/github.com/gin-gonic/gin/gin.go:600 +0x1aa
golang.org/x/net/http2/h2c.h2cHandler.ServeHTTP({{0x1271c20?, 0xc0003a2d00?}, 0xc0003fe620?}, {0x1278678, 0xc00048e128}, 0xc0002617c0)
	/go/src/pcf/vendor/golang.org/x/net/http2/h2c/h2c.go:125 +0x673
net/http.serverHandler.ServeHTTP({0x0?}, {0x1278678?, 0xc00048e128?}, 0x0?)
	/usr/local/go/src/net/http/server.go:3301 +0x8e
net/http.initALPNRequest.ServeHTTP({{0x1279238?, 0xc0003cb980?}, 0xc0003cea88?, {0xc0003de700?}}, {0x1278678, 0xc00048e128}, 0xc0002617c0)
	/usr/local/go/src/net/http/server.go:3974 +0x231
net/http.(*http2serverConn).runHandler(0x44b372?, 0xe1b83b?, 0xc0004451a0?, 0xc0004451d0?)
	/usr/local/go/src/net/http/h2_bundle.go:6529 +0xf5
created by net/http.(*http2serverConn).scheduleHandler in goroutine 21
	/usr/local/go/src/net/http/h2_bundle.go:6463 +0x21d
	{"component": "PCF", "category": "GIN"}
```
